### PR TITLE
Improve test coverage

### DIFF
--- a/R/ContextTorch.R
+++ b/R/ContextTorch.R
@@ -34,10 +34,12 @@ ContextTorch = R6Class("ContextTorch",
     #'   The optimizer.
     #' @param loss_fn ([`torch::nn_module`])\cr
     #'   The loss function.
-    #' @param total_epochs (integer(1))\cr
+    #' @param total_epochs (`integer(1)`)\cr
     #'   The total number of epochs the learner is trained for.
+    #' @param prediction_encoder (`function()`)\cr
+    #'   The learner's prediction encoder.
     initialize = function(learner, task_train, task_valid = NULL, loader_train, loader_valid = NULL,
-      measures_train = NULL, measures_valid = NULL, network, optimizer, loss_fn, total_epochs) {
+      measures_train = NULL, measures_valid = NULL, network, optimizer, loss_fn, total_epochs, prediction_encoder) {
       self$learner = assert_r6(learner, "Learner")
       self$task_train = assert_r6(task_train, "Task")
       self$task_valid = assert_r6(task_valid, "Task", null.ok = TRUE)
@@ -53,6 +55,7 @@ ContextTorch = R6Class("ContextTorch",
       self$total_epochs = assert_integerish(total_epochs, lower = 0, any.missing = FALSE)
       self$last_scores_train = structure(list(), names = character(0))
       self$last_scores_valid = structure(list(), names = character(0))
+      self$prediction_encoder = assert_function(prediction_encoder, args = c("predict_tensor", "task"))
       self$epoch = 0
       self$batch = 0
     },
@@ -100,6 +103,9 @@ ContextTorch = R6Class("ContextTorch",
     epoch = NULL,
     #' @field batch (`integer(1)`)\cr
     #'   The current iteration of the batch.
-    batch = NULL
+    batch = NULL,
+    #' @field prediction_encoder (`function()`)\cr
+    #'   The learner's prediction encoder.
+    prediction_encoder = NULL
   )
 )

--- a/R/paramset_torchlearner.R
+++ b/R/paramset_torchlearner.R
@@ -12,6 +12,11 @@ make_check_measures = function(task_type) {
     if (!test_names(ids(x), type = "unique")) {
       return("IDs of measures must be unique.")
     }
+    # CallbackSetHistory has a column 'epoch' in a data.table, where all other columns are the ids
+    # of the measures
+    if ("epoch" %in% ids(x)) {
+      stopf("Measure must not have id 'epoch'.")
+    }
     # some measures have task_type NA, which means they work with all task types
     if (!all(map_lgl(map(x, "task_type"), function(x) task_type %in% x || (length(x) == 1L && is.na(x))))) {
       return(sprintf("Measures must support task type \"%s\".", task_type))

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -127,3 +127,5 @@ register_mlr3pipelines = function() {
   mlr_reflections$pipeops$valid_tags = setdiff(mlr_reflections$pipeops$valid_tags, mlr3torch_pipeop_tags)
   mlr_reflections$learner_feature_types = setdiff(mlr_reflections$learner_feature_types, mlr3torch_feature_types)
 }
+
+leanify_package()

--- a/README.Rmd
+++ b/README.Rmd
@@ -41,8 +41,8 @@ remotes::install_github("mlr-org/mlr3torch")
 
 ## Status
 
-`mlr3torch` is currently still unstable but under active development.
-Not everything might work yet and the API might change without notice.
+`mlr3torch` is currently still unstable.
+Not everything ill work yet and the API might change without notice.
 
 ## What is mlr3torch?
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ remotes::install_github("mlr-org/mlr3torch")
 
 ## Status
 
-`mlr3torch` is currently still unstable but under active development.
-Not everything might work yet and the API might change without notice.
+`mlr3torch` is currently still unstable. Not everything ill work yet and
+the API might change without notice.
 
 ## What is mlr3torch?
 

--- a/man/mlr_context_torch.Rd
+++ b/man/mlr_context_torch.Rd
@@ -70,6 +70,9 @@ The current epoch.}
 
 \item{\code{batch}}{(\code{integer(1)})\cr
 The current iteration of the batch.}
+
+\item{\code{prediction_encoder}}{(\verb{function()})\cr
+The learner's prediction encoder.}
 }
 \if{html}{\out{</div>}}
 }
@@ -97,7 +100,8 @@ Creates a new instance of this \link[R6:R6Class]{R6} class.
   network,
   optimizer,
   loss_fn,
-  total_epochs
+  total_epochs,
+  prediction_encoder
 )}\if{html}{\out{</div>}}
 }
 
@@ -134,8 +138,11 @@ The optimizer.}
 \item{\code{loss_fn}}{(\code{\link[torch:nn_module]{torch::nn_module}})\cr
 The loss function.}
 
-\item{\code{total_epochs}}{(integer(1))\cr
+\item{\code{total_epochs}}{(\code{integer(1)})\cr
 The total number of epochs the learner is trained for.}
+
+\item{\code{prediction_encoder}}{(\verb{function()})\cr
+The learner's prediction encoder.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test_LearnerTorch.R
+++ b/tests/testthat/test_LearnerTorch.R
@@ -6,6 +6,17 @@ test_that("Correct error when trying to create deep clone of trained network", {
   expect_error(learner$clone(deep = TRUE), regexp = "Deep clone of trained network is currently not supported")
 })
 
+test_that("Correct error when using problematic measures", {
+  learner = lrn("classif.torch_featureless", epochs = 1, batch_size = 16, measures_train = msr("classif.bbrier"))
+  task = tsk("german_credit")
+  expect_error(learner$train(task), "Change the predict type or select other measures")
+})
+
+test_that("Correct error when providing measure with id 'epoch'", {
+  m = msr("classif.acc")
+  m$id = "epoch"
+  expect_error(lrn("classif.torch_featureless", measures_train = m), "must not have id")
+})
 
 test_that("Basic tests: Classification", {
   learner = LearnerTorchTest1$new(task_type = "classif")
@@ -91,10 +102,9 @@ test_that("Parameters cannot start with {loss, opt, cb}.", {
     )$new()
   }
 
-  # TODO: regex
-  expect_error(helper(ps(loss.weight = p_dbl())))
-  expect_error(helper(ps(opt.weight = p_dbl())))
-  expect_error(helper(ps(cb.weight = p_dbl())))
+  expect_error(helper(ps(loss.weight = p_dbl())), "are reserved for")
+  expect_error(helper(ps(opt.weight = p_dbl())), "are reserved for")
+  expect_error(helper(ps(cb.weight = p_dbl())), "are reserved for")
 })
 
 test_that("ParamSet reference identities are preserved after a deep clone", {
@@ -145,50 +155,225 @@ test_that("Train-predict loop is reproducible when setting a seed", {
   expect_identical(p1$prob, p2$prob)
 })
 
+test_that("the state of a trained network contains what it should", {
+  task = tsk("mtcars")
+  learner = lrn("regr.torch_featureless", epochs = 0, batch_size = 10,
+    callbacks = t_clbk("history", id = "history1"),
+    optimizer = t_opt("sgd", lr = 1),
+    loss = t_loss("l1")
+  )
+  learner$train(task)
+  expect_permutation(names(learner$model), c("seed", "network", "optimizer", "loss_fn", "task_col_info", "callbacks"))
+  expect_true(is.integer(learner$model$seed))
+  expect_class(learner$model$network, "nn_module")
+  expect_class(learner$model$loss_fn, "nn_l1_loss")
+  expect_class(learner$model$optimizer, "optim_sgd")
+  expect_list(learner$model$callbacks, types = "CallbackSet", len = 1L)
+  expect_equal(names(learner$model$callbacks), "history1")
+  expect_true(is.integer(learner$model$seed))
+  expect_equal(task$col_info, learner$model$task_col_info)
+})
 
-# test_that("Bundling works",{
-#   callr::r(function() {
-#     library(mlr3torch)
-#     module =
-#     learner = lrn()
-#   })
-# })
-#
-# test_that("assemble and dissamble work.", {
-#   callr::r(function() {
-#     library(mlr3torch)
-#     learner = lrn("")
-#
-#
-#   })
-#   f = function() {
-#     library(mlr3torch)
-#     devtools::load_all("~/mlr/mlr3torch")
-#     learner = mlr3::lrn("classif.mlp",
-#       layers = 2L,
-#       p = 0.2,
-#       batch_size = 16L,
-#       epochs = 1L,
-#       d_hidden = 10,
-#       activation = "relu",
-#       optimizer = "adam"
-#     )
-#     task = mlr3::tsk("iris")
-#
-#     learner$train(task)
-#     learner$serialize()
-#     saveRDS(learner, "~/.lol/loeerna.R")
-#
-#   }
-#   callr::r(f)
-#   learner = readRDS("~/.lol/loeerna.R")
-#   learner$unserialize()
-#   learner$train(task)
-#
-#   dir = tempfile(fileext = ".rds")
-#   saveRDS(learner, dir)
-#   learner_ = readRDS(dir)
-#
-#   saveRDS(learner$s)
-# })
 
+test_that("train parameters do what they should: classification and regression", {
+  # Currently available train parameters:
+  # * batch_size
+  # * epochs
+  # * device
+  # * measures_train
+  # * measures_valid
+  # * drop_last
+  # * shuffle
+  # * num_threads
+  # * seed (reproducibility is already tested somewhere else)
+
+  callback = torch_callback(id = "internals",
+    on_begin = function() {
+      # rename to avoid deleting the ctx after finishing the training
+      self$ctx1 = self$ctx
+      self$num_threads = torch_get_num_threads()
+    }
+  )
+
+  f = function(task_type, measure_ids) {
+    task = switch(task_type, regr = tsk("mtcars"), classif = tsk("iris"))
+    epochs = sample(3, 1)
+    batch_size = sample(16, 1)
+    shuffle = sample(c(TRUE, FALSE), 1)
+    num_threads = sample(2, 1)
+    drop_last = sample(c(TRUE, FALSE), 1)
+    seed = sample.int(10, 1)
+    measures_train = msrs(paste0(measure_ids[sample(c(TRUE, FALSE, TRUE), 3, replace = FALSE)]))
+    measures_valid = msrs(paste0(measure_ids[sample(c(TRUE, FALSE, TRUE), 3, replace = FALSE)]))
+
+    learner = lrn(paste0(task_type, ".torch_featureless"),
+      epochs = epochs,
+      batch_size = batch_size,
+      callbacks = list(callback, t_clbk("history")),
+      shuffle = shuffle,
+      num_threads = num_threads,
+      drop_last = drop_last,
+      seed = seed,
+      measures_train = measures_train,
+      measures_valid = measures_valid,
+      predict_type = switch(task_type, classif = "prob", regr = "response")
+
+    )
+
+    # first we test everything with validation
+
+    split = partition(task)
+    task$row_roles$use = split$train
+    task$row_roles$test = split$train
+    learner$train(task)
+
+    internals = learner$model$callbacks$internals
+    ctx = internals$ctx1
+
+    expect_equal(num_threads, internals$num_threads)
+    expect_equal(ctx$loader_train$batch_size, batch_size)
+    expect_equal(ctx$loader_valid$batch_size, batch_size)
+    expect_equal(ctx$total_epochs, epochs)
+    expect_equal(ctx$network$parameters[[1]]$device$type, "cpu")
+
+    if (shuffle) {
+      expect_class(ctx$loader_train$sampler, "utils_sampler_random")
+    } else {
+      expect_class(ctx$loader_train$sampler, "utils_sampler_sequential")
+    }
+    expect_class(ctx$loader_valid$sampler, "utils_sampler_sequential")
+    if (drop_last) {
+      expect_true(ctx$loader_train$drop_last)
+    } else {
+      expect_false(ctx$loader_train$drop_last)
+    }
+
+    expect_false(ctx$loader_valid$drop_last)
+
+    expect_equal(nrow(learner$history$valid), epochs)
+    expect_equal(nrow(learner$history$train), epochs)
+    expect_permutation(c("epoch", ids(measures_train)), colnames(learner$history$train))
+    expect_permutation(c("epoch", ids(measures_valid)), colnames(learner$history$valid))
+
+    # now without validation
+    task$row_roles$test = integer()
+
+    learner$state = NULL
+    learner$train(task)
+
+    expect_equal(nrow(learner$model$callbacks$history$valid), 0)
+
+
+    learner$state = NULL
+    learner$param_set$set_values(
+      device = "meta",
+      epochs = 0
+    )
+
+    # now we also test that the device placement works
+    learner$train(task)
+    expect_equal(learner$network$parameters[[1]]$device$type, "meta")
+
+  }
+
+  f("regr", c("regr.mse", "regr.rmse", "regr.mae"))
+  f("classif", c("classif.acc", "classif.ce", "classif.mbrier"))
+})
+
+test_that("predict types work during training and prediction", {
+  # Here we check that when setting the predict type to "prob", they are available during training
+  # (and hence also for validation)
+  task = tsk("iris")
+  learner = lrn("classif.torch_featureless", epochs = 1, batch_size = 16, predict_type = "prob",
+    measures_train = msr("classif.mbrier"), callbacks = t_clbk("history"))
+  learner$train(task)
+  expect_true(!is.na(learner$history$train[1, "classif.mbrier"][[1L]]))
+
+  pred = learner$predict(task)
+  expect_true(is.matrix(pred$prob))
+  expect_true(is.factor(pred$response))
+  expect_equal(levels(pred$response), task$class_names)
+  expect_permutation(colnames(pred$prob), task$class_names)
+  expect_prediction_classif(pred)
+
+  learner$predict_type = "response"
+  pred = learner$predict(task)
+  expect_true(is.null(pred$prob))
+  expect_true(is.factor(pred$response))
+  expect_equal(levels(pred$response), task$class_names)
+  expect_prediction_classif(pred)
+})
+
+test_that("predict parameters do what they should: classification and regression", {
+  # Currently available predict parameters:
+  # * batch_size
+  # * device
+  # * num_threads
+  # * seed (already checked somewhere else)
+
+  callback = torch_callback(id = "internals",
+    on_begin = function() {
+      # Rename so it won't get deleted after training finishes
+      self$ctx1 = self$ctx
+      self$num_threads = torch_get_num_threads()
+    }
+  )
+
+  f = function(task_type) {
+    num_threads = sample(2, 1)
+    batch_size = sample(16, 1)
+    learner = lrn(paste0(task_type, ".torch_featureless"), epochs = 1, callbacks = callback,
+      num_threads = num_threads,
+      batch_size = batch_size
+    )
+    task = switch(task_type, regr = tsk("mtcars"), classif = tsk("iris"))
+    learner$train(task)
+    internals = learner$model$callbacks$internals
+    ctx = internals$ctx1
+    expect_equal(num_threads, internals$num_threads)
+    task$row_roles$use = integer(0)
+
+    learner$param_set$set_values(device = "meta")
+    task$row_roles$use = 1
+    try(learner$predict(task), silent = TRUE)
+    expect_equal(learner$network$parameters[[1]]$device$type, "meta")
+  }
+
+  f("regr")
+  f("classif")
+})
+
+test_that("quick accessors work", {
+  task = tsk("mtcars")
+  learner = lrn("regr.torch_featureless", epochs = 1, batch_size = 1, callbacks = "history")
+  expect_error(learner$network, "Cannot")
+  expect_error(learner$history, "Cannot")
+  learner$train(task)
+  expect_class(learner$network, "nn_module")
+  expect_class(learner$history, "CallbackSetHistory")
+  learner = lrn("regr.torch_featureless", epochs = 1, batch_size = 1)
+  learner$train(task)
+  expect_error(learner$history, "No history found")
+})
+
+test_that("Train-Predict works", {
+  learner = lrn("classif.torch_featureless", epochs = 1, device = "cpu", batch_size = 16)
+  task = tsk("iris")
+  split = partition(task)
+  learner$train(task, row_ids = split$train)
+  pred = learner$predict(task, row_ids = split$test)
+
+  expect_prediction_classif(pred)
+
+  expect_equal(task$truth(split$test), pred$truth)
+})
+
+# This should not really be needed but see:
+# https://github.com/mlr-org/mlr3/issues/947
+test_that("resample() works", {
+  learner = lrn("regr.torch_featureless", epochs = 1, batch_size = 50)
+  task = tsk("mtcars")
+  resampling = rsmp("holdout")
+  rr = resample(task, learner, resampling)
+  expect_r6(rr, "ResampleResult")
+})

--- a/tests/testthat/test_learner_torch_methods.R
+++ b/tests/testthat/test_learner_torch_methods.R
@@ -115,15 +115,15 @@ test_that("learner_torch_predict works", {
 
 })
 
-test_that("encode_prediction works", {
+test_that("encode_prediction_default works", {
   task = tsk("iris")
 
   # classif
   pt = torch_rand(task$nrow, length(task$class_names))
   pt = pt / torch_sum(pt, 2L)$reshape(c(150, 1))
 
-  p1 = encode_prediction(pt, "response", task)
-  p2 = encode_prediction(pt, "prob", task)
+  p1 = encode_prediction_default(pt, "response", task)
+  p2 = encode_prediction_default(pt, "prob", task)
 
   pd1 = as_prediction_data(p1, task)
   pd2 = as_prediction_data(p2, task)

--- a/tests/testthat/test_paramset_torchlearner.R
+++ b/tests/testthat/test_paramset_torchlearner.R
@@ -23,9 +23,10 @@ test_that("paramset works", {
   expect_error(param_set_classif$set_values(measures_valid = msr("classif.acc")), regexp = NA)
   expect_error(param_set_classif$set_values(measures_train = msr("regr.mse")), regexp = "classif")
   expect_error(param_set_classif$set_values(measures_valid = msr("regr.mse")), regexp = "classif")
+  expect_error(param_set_classif$set_values(measures_train = msr("selected_features")), regexp = "must not require")
 
 
-  expect_error({param_set_regr$values$device = "opengl"}, regexp = NA)
+  expect_error({param_set_regr$values$device = "opengl"}, regexp = NA) # nolint
 })
 
 test_that("make_check_measures works", {

--- a/vignettes/pipeop_torch.Rmd
+++ b/vignettes/pipeop_torch.Rmd
@@ -394,7 +394,8 @@ lr_sequential$param_set$set_values(
   epochs = 50,
   measures_train = msrs(c("classif.logloss", "classif.ce"))
 )
-lr_sequential$predict_type = "response"
+# This is required to evaluate the logloss during training
+lr_sequential$predict_type = "prob"
 
 lr_sequential$train(md_sequential$task)
 ```


### PR DESCRIPTION
* `mlr3misc::leanify()` the package
* Because of a bug in mlr3 we need to store the task's column info ourselves: https://github.com/mlr-org/mlr3/issues/947 (we do this temporarily because of the factor level bug 
* The learner's predict type is now used to encode the predictions during training
* An additional check on the parameters `measures_valid` and `measures_train` is performed at the beginning of the training loop to err if the measure requires a different predict type than the one that is set for the learner
* Bugfix: Move the network to the device during prediction
* Add check that measures can't have ID "epoch" (otherwise there might be conflicting column names in the history)
* Improve test coverage of the `LearnerTorch` class.