### PR TITLE
Magick to base loader

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,6 @@ Suggests:
     igraph,
     jsonlite,
     knitr,
-    magick,
     mlr3tuning (>= 1.0.0),
     progress,
     rmarkdown,

--- a/R/LearnerTorchImage.R
+++ b/R/LearnerTorchImage.R
@@ -31,7 +31,7 @@ LearnerTorchImage = R6Class("LearnerTorchImage",
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
     initialize = function(id, task_type, param_set = ps(), label, optimizer = NULL, loss = NULL,
-      callbacks = list(), packages = c("torchvision"), man, properties = NULL,
+      callbacks = list(), packages = "torchvision", man, properties = NULL,
       predict_types = NULL) {
       properties = properties %??% switch(task_type,
         regr = c(),

--- a/R/LearnerTorchImage.R
+++ b/R/LearnerTorchImage.R
@@ -31,7 +31,7 @@ LearnerTorchImage = R6Class("LearnerTorchImage",
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
     initialize = function(id, task_type, param_set = ps(), label, optimizer = NULL, loss = NULL,
-      callbacks = list(), packages = c("torchvision", "magick"), man, properties = NULL,
+      callbacks = list(), packages = c("torchvision"), man, properties = NULL,
       predict_types = NULL) {
       properties = properties %??% switch(task_type,
         regr = c(),

--- a/R/utils.R
+++ b/R/utils.R
@@ -178,7 +178,7 @@ dataset_image = dataset("image_dataset",
     self$uris = uris
   },
   .getitem = function(x) {
-    list(x = torchvision::transform_to_tensor(magick::image_read(self$uris[x])))
+    list(x = torchvision::transform_to_tensor(torchvision::base_loader(self$uris[x])))
   },
   .length = function() {
     length(self$uris)

--- a/man/mlr_learners.torchvision.Rd
+++ b/man/mlr_learners.torchvision.Rd
@@ -90,9 +90,9 @@ Krizhevsky, Alex, Sutskever, Ilya, Hinton, E. G (2017).
 Sandler, Mark, Howard, Andrew, Zhu, Menglong, Zhmoginov, Andrey, Chen, Liang-Chieh (2018).
 \dQuote{Mobilenetv2: Inverted residuals and linear bottlenecks.}
 In \emph{Proceedings of the IEEE conference on computer vision and pattern recognition}, 4510--4520.
-He, Kaiming, Zhang, Xiangyu, Ren, Shaoqing, Sun, Jian (2016).
-\dQuote{Deep residual learning for image recognition.}
-In \emph{Proceedings of the IEEE conference on computer vision and pattern recognition}, 770--778.
+He, Kaiming, Zhang, Xiangyu, Ren, Shaoqing, Sun, Jian (2016 ).
+\dQuote{Deep residual learning for image recognition .}
+In \emph{Proceedings of the IEEE conference on computer vision and pattern recognition }, 770--778 .
 Simonyan, Karen, Zisserman, Andrew (2014).
 \dQuote{Very deep convolutional networks for large-scale image recognition.}
 \emph{arXiv preprint arXiv:1409.1556}.}

--- a/man/mlr_learners_torch_image.Rd
+++ b/man/mlr_learners_torch_image.Rd
@@ -64,7 +64,7 @@ Creates a new instance of this \link[R6:R6Class]{R6} class.
   optimizer = NULL,
   loss = NULL,
   callbacks = list(),
-  packages = c("torchvision", "magick"),
+  packages = c("torchvision"),
   man,
   properties = NULL,
   predict_types = NULL

--- a/man/mlr_pipeops_nn_adaptive_avg_pool1d.Rd
+++ b/man/mlr_pipeops_nn_adaptive_avg_pool1d.Rd
@@ -27,7 +27,7 @@ Part of this documentation have been copied or adapted from the documentation of
 \section{Parameters}{
 
 \itemize{
-\item \code{output_size} :: \code{integer()}\cr
+\item \code{output_size} :: \code{integer(1)}\cr
 The target output size. A single number.
 }
 }

--- a/tests/testthat/test_LearnerTorchVision.R
+++ b/tests/testthat/test_LearnerTorchVision.R
@@ -17,7 +17,6 @@ test_that("LearnerTorchVision basic checks", {
   vgg13$id = "a"
   expect_false(alexnet$phash == vgg13$phash)
   expect_true("torchvision" %in% alexnet$packages)
-  expect_true("magick" %in% alexnet$packages)
 
   alexnet = lrn("classif.alexnet", optimizer = "sgd", loss = "cross_entropy",
     callbacks = t_clbk("checkpoint"), epochs = 0, batch_size = 1


### PR DESCRIPTION
Remove usage magick::image_read()` since it appears to be around half as fast as `torchvision::base_loader()`