### PR TITLE
fix lazy tensor materialization

### DIFF
--- a/R/materialize.R
+++ b/R/materialize.R
@@ -163,7 +163,7 @@ materialize_internal = function(x, device = "cpu", cache = NULL, rbind) {
   data_descriptor = dd(x)
   ds = data_descriptor$dataset
   graph = data_descriptor$graph
-  varying_shapes = some(data_descriptor$dataset_shapes, is.null)
+  varying_shapes = is.null(data_descriptor$dataset$.getbatch) && some(data_descriptor$dataset_shapes, function(x) is.null(x) || anyNA(x[-1]))
 
   pointer_name = paste0(data_descriptor$pointer, collapse = ".")
   if (do_caching) {


### PR DESCRIPTION
Because we now allow for `NA`s in non-batch dimensions, there was a lingering bug when materializing a lazy tensor with e.g. shapes `c(NA, NA)` but which does implement `$.getbatch()`, which can happen when padding data.