### PR TITLE
instantiate sampler in .dataloader

### DIFF
--- a/R/LearnerTorch.R
+++ b/R/LearnerTorch.R
@@ -534,7 +534,7 @@ LearnerTorch = R6Class("LearnerTorch",
       args = param_vals[names(param_vals) %in% dl_args]
       for(param_name in c("sampler", "batch_sampler")){
         param_val <- args[[param_name]]
-        if(!is.null(param_val)){
+        if (!is.null(param_val)) {
           # instantiate these params which should be classes.
           args[[param_name]] = param_val(dataset)
         }


### PR DESCRIPTION
closes #417 

In current master, the code below gives an error. Using this branch, it works (no error).
```r
remotes::install_github("tdhock/mlr3torch@fix-sampler")
rev_sampler_class <- torch::sampler(
  "MySampler",
  initialize = function(data_source) {
    print('init')
    self$data_source <- data_source
  },
  .iter = function() {
    count <<- 0L
    function() {
      if (count < length(self$data_source)) {
        idx <- length(self$data_source)-count
        count <<- count + 1L
        return(idx)
      }
      coro::exhausted()
    }
  },
  .length = function() {
    length(self$data_source)
  }
)
sonar_task <- mlr3::tsk("sonar")
mlp_learner <- mlr3torch::LearnerTorchMLP$new(task_type="classif")
mlp_learner$param_set$set_values(
  epochs=10,
  batch_size=20,
  sampler=rev_sampler_class)
mlp_learner$train(sonar_task)
```
@sebffischer can you please review and tell me if this change would be acceptable?
If so I can add documentation and tests.

I wonder if we should do the same for param `batch_sampler` ? What is the difference with param `sampler` ?