### PR TITLE
learner$train() informative error for incorrect sampler

### DIFF
--- a/R/learner_torch_methods.R
+++ b/R/learner_torch_methods.R
@@ -150,6 +150,12 @@ train_loop = function(ctx, cbs) {
     while (ctx$step < length(ctx$loader_train)) {
       ctx$step = ctx$step + 1
       ctx$batch = dataloader_next(train_iterator)
+      print(ctx$step)
+      print(ctx$batch)
+      browser(expr=tryCatch({
+        ctx$batch$y$to(device = ctx$device)
+        FALSE
+      }, error=function(e)TRUE))
       ctx$batch$x = lapply(ctx$batch$x, function(x) x$to(device = ctx$device))
       ctx$batch$y = ctx$batch$y$to(device = ctx$device)
       ctx$optimizer$zero_grad()

--- a/R/learner_torch_methods.R
+++ b/R/learner_torch_methods.R
@@ -151,7 +151,7 @@ train_loop = function(ctx, cbs) {
       ctx$step = ctx$step + 1
       ctx$batch = dataloader_next(train_iterator)
       if (is.null(ctx$batch)) {
-        stop("dataloader_next returned NULL, which means there are no more samples/batches. Typically this occurs when sampler/batch_sampler$length() is greater than the number of samples/batches. Please modify .length() method to return the correct number (samples for sampler, batches for batch_sampler), which should be equal to the number of times that .iter() can be called before returning coro::exhausted()")
+        stop("dataloader_next() returned NULL, which means there are no more samples/batches. Typically this occurs when length of sampler/batch_sampler is greater than the number of samples/batches. Please modify .length() method to return the correct number (samples for sampler, batches for batch_sampler), which should be equal to the number of times that .iter() can be called before returning coro::exhausted()")
       }
       ctx$batch$x = lapply(ctx$batch$x, function(x) x$to(device = ctx$device))
       ctx$batch$y = ctx$batch$y$to(device = ctx$device)

--- a/R/learner_torch_methods.R
+++ b/R/learner_torch_methods.R
@@ -150,12 +150,9 @@ train_loop = function(ctx, cbs) {
     while (ctx$step < length(ctx$loader_train)) {
       ctx$step = ctx$step + 1
       ctx$batch = dataloader_next(train_iterator)
-      print(ctx$step)
-      print(ctx$batch)
-      browser(expr=tryCatch({
-        ctx$batch$y$to(device = ctx$device)
-        FALSE
-      }, error=function(e)TRUE))
+      if (is.null(ctx$batch)) {
+        stop("dataloader_next returned NULL, which means there are no more samples/batches. Typically this occurs when sampler/batch_sampler$length() is greater than the number of samples/batches. Please modify .length() method to return the correct number (samples for sampler, batches for batch_sampler), which should be equal to the number of times that .iter() can be called before returning coro::exhausted()")
+      }
       ctx$batch$x = lapply(ctx$batch$x, function(x) x$to(device = ctx$device))
       ctx$batch$y = ctx$batch$y$to(device = ctx$device)
       ctx$optimizer$zero_grad()


### PR DESCRIPTION
Closes https://github.com/mlr-org/mlr3torch/issues/420

This PR affects this code example https://github.com/mlr-org/mlr3torch/issues/420#issuecomment-3258345194

Before this PR we get
```r
> inst_learner$train(sonar_task)
Error in ctx$batch$y$to(device = ctx$device) : 
  attempt to apply non-function
```
After this PR we get a more informative error which should be able to help the user do a fix:
```r
Error in train_loop(ctx, callbacks) (from mlr3torch-bug.R#55) : 
  dataloader_next() returned NULL, which means there are no more samples/batches. Typically this occurs when length of sampler/batch_sampler is greater than the number of samples/batches. Please modify .length() method to return the correct number (samples for sampler, batches for batch_sampler), which should be equal to the number of times that .iter() can be called before returning coro::exhausted()
```