### PR TITLE
fix: packages

### DIFF
--- a/R/LearnerTorch.R
+++ b/R/LearnerTorch.R
@@ -357,7 +357,7 @@ LearnerTorch = R6Class("LearnerTorch",
         }
         private$.callbacks = callbacks
         private$.param_set = NULL
-        self$packages = unique(c(self$packages, unlist(map(private$.callbacks, "packages"))))
+        self$packages = unique(c(self$packages, unlist(map(private$.callbacks, "packages")))) %??% character(0)
       }
       private$.callbacks
     },


### PR DESCRIPTION
`mlr3` validates the field now. Usually `Learner$initialize` sets this to `character(0)`.