### PR TITLE
fix: skip the broken pima task when building task tables

### DIFF
--- a/tests/testthat/test_dictionaries.R
+++ b/tests/testthat/test_dictionaries.R
@@ -26,6 +26,15 @@ test_that("mlr3torch_losses can be converted to a table", {
 test_that("mlr_tasks can be converted to a table without downloading imagenet", {
   dir = tempfile()
   withr::local_options(mlr3torch.cache = dir)
+  # as.data.table() constructs every task in the dictionary, and 'pima' currently fails to
+  # construct because mlbench no longer ships PimaIndiansDiabetes2. Drop it for this test and
+  # put it back afterwards.
+  # TODO: remove once this is fixed upstream in mlr3
+  if ("pima" %in% mlr_tasks$keys()) {
+    pima = mlr_tasks$items[["pima"]]
+    mlr_tasks$remove("pima")
+    withr::defer(mlr_tasks$add("pima", pima$value, .prototype_args = pima$prototype_args))
+  }
   expect_data_table(as.data.table(mlr_tasks))
   # nothing is in the cache directory -> imagenet was not downloaded
   expect_true(!dir.exists(dir))

--- a/vignettes/articles/task_list.Rmd
+++ b/vignettes/articles/task_list.Rmd
@@ -13,6 +13,11 @@ An overview of all tasks can also be found on the [mlr-org website](https://mlr-
 ```{r, echo = FALSE, message = FALSE}
 library(data.table)
 library(mlr3torch)
+# as.data.table() constructs every task in the dictionary, and 'pima' currently fails to
+# construct because mlbench no longer ships PimaIndiansDiabetes2. Drop it beforehand; it is not
+# an mlr3torch task, so it never appears in the table below anyway.
+# TODO: remove once this is fixed upstream in mlr3
+if ("pima" %in% mlr3::mlr_tasks$keys()) mlr3::mlr_tasks$remove("pima")
 content = as.data.table(mlr3::mlr_tasks)[, .(key, label, task_type, nrow, ncol)]
 mlr3torch_ids = names(getFromNamespace("mlr3torch_tasks", "mlr3torch"))
 content = content[key %in% mlr3torch_ids]


### PR DESCRIPTION
mlbench no longer ships PimaIndiansDiabetes2, so constructing mlr3's 'pima' task errors with "no applicable method for 'as_data_backend' applied to an object of class NULL". This breaks anything that converts the task dictionary to a table, because as.data.table() constructs every task: the pkgdown build (vignettes/articles/task_list.Rmd) and test_dictionaries.R.

Remove the 'pima' entry before the conversion in both places, guarded by a keys() check so it becomes a no-op once mlr3 fixes the task upstream. The test restores the entry afterwards so the dictionary is unchanged for later tests. The vignette table only lists mlr3torch tasks, so its output is unaffected.