### PR TITLE
feat: give callbacks access to the other callbacks of the run

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,9 @@
 * Exported various helpers useful for implementing shape inference for custom `PipeOpTorch` classes.
 * `ModelDescriptor()` now accepts a known batch dimension in `pointer_shape`, so an operator can
   check what it would otherwise have to assume, e.g. that a reshape keeps the batch dimension.
+* `ContextTorch` has a new field `$callbacks`, which gives a callback access to the other callbacks
+  of the training run, named by their ids.
+* `ContextTorch$epoch` is now `0` during the `on_begin` stage instead of `NULL`.
 
 ## Breaking changes
 

--- a/R/ContextTorch.R
+++ b/R/ContextTorch.R
@@ -137,6 +137,11 @@ ContextTorch = R6Class("ContextTorch",
     #' @field terminate (`logical(1)`)\cr
     #'   If this field is set to `TRUE` at the end of an epoch, training stops.
     terminate = NULL,
+    #' @field callbacks (named `list()` of [`CallbackSet`]s)\cr
+    #'   The callbacks that are active during training, named by their ids.
+    #'   This allows a callback to access the state of the other callbacks, which is for example
+    #'   what [`CallbackSetCheckpoint`] does to save them.
+    callbacks = NULL,
     #' @field device (`torch::torch_device`)\cr
     #'   The device.
     device = NULL

--- a/R/learner_torch_methods.R
+++ b/R/learner_torch_methods.R
@@ -115,6 +115,9 @@ learner_torch_train = function(self, private, super, task, param_vals) {
 
 
 train_loop = function(ctx, cbs) {
+  # callbacks such as CallbackSetCheckpoint need access to the other callbacks to save their states
+  ctx$callbacks = cbs
+
   call = function(step_name) {
     lapply(cbs, function(x) {
       if (exists(step_name, x, inherits = FALSE)) {
@@ -131,13 +134,14 @@ train_loop = function(ctx, cbs) {
   }, add = TRUE)
 
 
+  # if we increment epoch at the end of the loop it has the wrong value
+  # during the final two callback stages
+  ctx$epoch = 0L
+
   call("on_begin")
 
   ctx$network$train()
 
-  # if we increment epoch at the end of the loop it has the wrong value
-  # during the final two callback stages
-  ctx$epoch = 0L
   while (ctx$epoch < ctx$total_epochs) {
     ctx$epoch = ctx$epoch + 1
     call("on_epoch_begin")

--- a/man/mlr_context_torch.Rd
+++ b/man/mlr_context_torch.Rd
@@ -99,6 +99,11 @@ The current batch.}
     \item{\code{terminate}}{(\code{logical(1)})\cr
 If this field is set to \code{TRUE} at the end of an epoch, training stops.}
 
+    \item{\code{callbacks}}{(named \code{list()} of \code{\link{CallbackSet}}s)\cr
+The callbacks that are active during training, named by their ids.
+This allows a callback to access the state of the other callbacks, which is for example
+what \code{\link{CallbackSetCheckpoint}} does to save them.}
+
     \item{\code{device}}{(\code{torch::torch_device})\cr
 The device.}
   }

--- a/tests/testthat/test_ContextTorch.R
+++ b/tests/testthat/test_ContextTorch.R
@@ -1,0 +1,23 @@
+test_that("the context exposes the callbacks of the training run", {
+  seen = NULL
+  spy = torch_callback("spy", on_begin = function() seen <<- self$ctx$callbacks)
+
+  learner = lrn("classif.mlp", epochs = 1L, batch_size = 50, neurons = 10,
+    callbacks = list(spy, t_clbk("history")))
+  learner$train(tsk("iris"))
+
+  expect_names(names(seen), permutation.of = c("spy", "history"))
+  expect_class(seen$history, "CallbackSetHistory")
+  # the live callbacks, not copies: they share the context of the run
+  expect_identical(seen$history$ctx, seen$spy$ctx)
+})
+
+test_that("the epoch is 0 during the 'begin' stage", {
+  epoch = NULL
+  spy = torch_callback("spy", on_begin = function() epoch <<- self$ctx$epoch)
+
+  learner = lrn("classif.mlp", epochs = 2L, batch_size = 50, neurons = 10, callbacks = spy)
+  learner$train(tsk("iris"))
+
+  expect_equal(epoch, 0L)
+})


### PR DESCRIPTION
`ContextTorch` has a new field `$callbacks`, holding the `CallbackSet`s that are active during training, named by their ids. A callback can therefore inspect the other callbacks of the run, which is what `t_clbk("checkpoint")` needs in order to save their states.

`ctx$epoch` is now set to 0 before the 'begin' stage rather than after it, so that it is a number rather than NULL in `on_begin()` -- and so that a callback can change where the loop starts.