### PR TITLE
feat: let callbacks control when they are called within a stage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,7 +40,7 @@
   same weight keep the order in which they were passed to the learner. It can be set via the
   `weight` argument of `callback_set()` / `torch_callback()`, or on an existing `TorchCallback`.
   `t_clbk("checkpoint")` has weight `Inf` and therefore now runs after the other callbacks, so it
-  saves the network and the optimizer as they left them -- previously a learning rate scheduler
+  saves the network and the optimizer as they left them. Previously a learning rate scheduler
   passed after it would step only after the optimizer had already been written.
 * The learning rate scheduling and unfreezing callbacks implement `$state_dict()` and
   `$load_state_dict()`, and the early stopping callback additionally stores its best score and
@@ -53,15 +53,14 @@
 * The `freq_type` parameter of `t_clbk("checkpoint")` was removed; checkpoints are now always
   written per epoch. `freq_type = "step"` named its files after the within-epoch step, which
   restarts at every epoch, so each epoch silently overwrote the checkpoints of the previous one.
-  Code that set `freq_type` -- including to its default `"epoch"` -- has to drop the argument.
 * The construction argument `only_batch_unknown` of `PipeOpTorch` was removed.
   Any dimension of an input shape can now be unknown, so `private$.shapes_out()` must always
   handle `NA`s and assert those dimensions it actually needs to be known.
 
 ## Bug fixes
 
-* `t_clbk("checkpoint")` no longer writes an epoch that was interrupted -- because training failed
-  or was stopped early -- under that epoch's own number, so `network<n>.pt` is now always the
+* `t_clbk("checkpoint")` no longer writes an epoch that was interrupted
+  under that epoch's own number, so `network<n>.pt` is now always the
   network at the *end* of epoch `n` rather than sometimes a half-trained one.
 * `t_clbk("checkpoint")` now accepts an existing empty directory as its `path`. Previously any
   existing directory was rejected, which made a pre-created output folder unusable and meant that

--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,13 @@
 * `ContextTorch` has a new field `$callbacks`, which gives a callback access to the other callbacks
   of the training run, named by their ids.
 * `ContextTorch$epoch` is now `0` during the `on_begin` stage instead of `NULL`.
+* `CallbackSet` has a new field `$weight` that controls when a callback is called within a stage:
+  callbacks with a higher weight are called after those with a lower one, and callbacks with the
+  same weight keep the order in which they were passed to the learner. It can be set via the
+  `weight` argument of `callback_set()` / `torch_callback()`, or on an existing `TorchCallback`.
+  `t_clbk("checkpoint")` has weight `Inf` and therefore now runs after the other callbacks, so it
+  saves the network and the optimizer as they left them -- previously a learning rate scheduler
+  passed after it would step only after the optimizer had already been written.
 * The learning rate scheduling and unfreezing callbacks implement `$state_dict()` and
   `$load_state_dict()`, and the early stopping callback additionally stores its best score and
   stagnation counter. The state of a training run can therefore be carried over into another one.

--- a/R/CallbackSet.R
+++ b/R/CallbackSet.R
@@ -209,7 +209,7 @@ callback_set = function(
     on_batch_valid_end = assert_function(on_batch_valid_end, nargs = 0, null.ok = TRUE),
     on_valid_end = assert_function(on_valid_end, nargs = 0, null.ok = TRUE),
     on_exit = assert_function(on_exit, nargs = 0, null.ok = TRUE),
-    # NULL is filtered out below, so that `inherit`ing from another callback keeps its weight
+    # NULL is filtered out below, so that inheriting from another callback keeps its weight
     weight = if (!is.null(weight)) assert_number(weight)
   )
 

--- a/R/CallbackSet.R
+++ b/R/CallbackSet.R
@@ -45,6 +45,16 @@
 #' * `end` :: Run after last epoch.
 #' * `exit` :: Run at last, using `on.exit()`.
 #'
+#' @section Ordering:
+#' Within a stage, callbacks are called in the order in which they were passed to the learner.
+#' A callback can override this via its `$weight` field: callbacks with a higher weight are called
+#' after those with a lower one, and callbacks with the same weight keep the order in which they
+#' were passed.
+#' The default weight is `0`.
+#' This matters for callbacks that observe what the others did, which is why
+#' [`CallbackSetCheckpoint`] has weight `Inf`: it always runs last and therefore saves the network
+#' and optimizer as the other callbacks left them at the end of the stage.
+#'
 #' @section Terminate Training:
 #' If training is to be stopped, it is possible to set the field `$terminate` of [`ContextTorch`].
 #' At the end of every epoch this field is checked and if it is `TRUE`, training stops.
@@ -59,6 +69,9 @@ CallbackSet = R6Class("CallbackSet",
     #'   The evaluation context for the callback.
     #'   This field should always be `NULL` except during the `$train()` call of the torch learner.
     ctx = NULL,
+    #' @field weight (`numeric(1)`)\cr
+    #'   Controls when this callback is called within a stage, see section *Ordering*.
+    weight = 0,
     #' @description
     #' Prints the object.
     #' @param ... (any)\cr
@@ -142,6 +155,9 @@ CallbackSet = R6Class("CallbackSet",
 #'   This is what will be available in the learner after training.
 #' @param load_state_dict (`function(state_dict)`)\cr
 #'   Function that loads a callback state.
+#' @param weight (`numeric(1)`)\cr
+#'   Controls when the callback is called within a stage, see section *Ordering* of [`CallbackSet`].
+#'   Defaults to `0`.
 #' @param lock_objects (`logical(1)`)\cr
 #'  Whether to lock the objects of the resulting [`R6Class`][R6::R6Class].
 #'  If `FALSE` (default), values can be freely assigned to `self` without declaring them in the
@@ -171,6 +187,7 @@ callback_set = function(
   state_dict = NULL,
   load_state_dict = NULL,
   initialize = NULL,
+  weight = NULL,
   public = NULL, private = NULL, active = NULL, parent_env = parent.frame(), inherit = CallbackSet,
   lock_objects = FALSE
   ) {
@@ -191,7 +208,9 @@ callback_set = function(
     on_batch_valid_begin = assert_function(on_batch_valid_begin, nargs = 0, null.ok = TRUE),
     on_batch_valid_end = assert_function(on_batch_valid_end, nargs = 0, null.ok = TRUE),
     on_valid_end = assert_function(on_valid_end, nargs = 0, null.ok = TRUE),
-    on_exit = assert_function(on_exit, nargs = 0, null.ok = TRUE)
+    on_exit = assert_function(on_exit, nargs = 0, null.ok = TRUE),
+    # NULL is filtered out below, so that `inherit`ing from another callback keeps its weight
+    weight = if (!is.null(weight)) assert_number(weight)
   )
 
   assert_function(initialize, null.ok = TRUE)

--- a/R/CallbackSetCheckpoint.R
+++ b/R/CallbackSetCheckpoint.R
@@ -41,6 +41,10 @@ CallbackSetCheckpoint = R6Class("CallbackSetCheckpoint",
   lock_objects = FALSE,
   # TODO: This should also save the learner itself
   public = list(
+    #' @field weight (`numeric(1)`)\cr
+    #'   `Inf`, so that this callback runs after all others and hence saves the network and
+    #'   optimizer as they are at the end of the stage, see section *Ordering* of [`CallbackSet`].
+    weight = Inf,
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
     initialize = function(path, freq) {

--- a/R/CallbackSetUnfreeze.R
+++ b/R/CallbackSetUnfreeze.R
@@ -112,9 +112,9 @@ CallbackSetUnfreeze = R6Class("CallbackSetUnfreeze",
       params = self$ctx$network$parameters
       names(params)[map_lgl(params, function(param) param$requires_grad)]
     },
-    # this is applied both when the state is loaded and at the end of $on_begin(), because the
-    # callbacks are executed in the order in which they were passed to the learner: whichever of
-    # the two runs last must have the final say, otherwise $on_begin() freezes the weights again
+    # this is applied both when the state is loaded and at the end of $on_begin(), because the order
+    # the callbacks run in is up to the user (see `$weight` of CallbackSet): whichever of the two
+    # runs last must have the final say, otherwise $on_begin() freezes the weights again
     .restore_trainable = function() {
       if (is.null(private$.prev_state)) return(NULL)
       weights = intersect(private$.prev_state$trainable, names(self$ctx$network$parameters))

--- a/R/LearnerTorch.R
+++ b/R/LearnerTorch.R
@@ -100,6 +100,8 @@
 #' @param callbacks (`list()` of [`TorchCallback`]s)\cr
 #'   The callbacks to use for training.
 #'   Defaults to an empty` list()`, i.e. no callbacks.
+#'   Within a stage they are called in the order in which they are provided, unless a callback
+#'   requests otherwise via its `$weight`, see section *Ordering* of [`CallbackSet`].
 #' @param jittable (`logical(1)`)\cr
 #'   Whether the model can be jit-traced. Default is `FALSE`.
 #'

--- a/R/TorchCallback.R
+++ b/R/TorchCallback.R
@@ -261,6 +261,7 @@ TorchCallback = R6Class("TorchCallback",
 #'   The default is `NULL`.
 #'
 #' @inheritSection mlr_callback_set Stages
+#' @inheritSection mlr_callback_set Ordering
 #'
 #' @section Internals:
 #' It first creates an `R6` class inheriting from [`CallbackSet`] (using [`callback_set()`]) and

--- a/R/TorchCallback.R
+++ b/R/TorchCallback.R
@@ -194,9 +194,13 @@ TorchCallback = R6Class("TorchCallback",
     #' @template param_man
     #' @param additional_args (`any`)\cr
     #'  Additional arguments if necessary. For learning rate schedulers, this is the torch::LRScheduler.
+    #' @param weight (`numeric(1)` or `NULL`)\cr
+    #'   Overwrites the `$weight` of the generated [`CallbackSet`], see its section *Ordering*.
+    #'   If `NULL` (default), the callback's own weight is kept.
     initialize = function(callback_generator, param_set = NULL, id = NULL,
-      label = NULL, packages = NULL, man = NULL, additional_args = NULL) {
+      label = NULL, packages = NULL, man = NULL, additional_args = NULL, weight = NULL) {
       assert_class(callback_generator, "R6ClassGenerator")
+      self$weight = weight
 
       param_set = assert_param_set(param_set %??% inferps(callback_generator))
       if ("ctx" %in% param_set$ids()) {
@@ -211,10 +215,26 @@ TorchCallback = R6Class("TorchCallback",
         man = man,
         additional_args = additional_args
       )
+    },
+    #' @description
+    #' Generates the [`CallbackSet`], applying `$weight` if it is set.
+    generate = function() {
+      cb = super$generate()
+      if (!is.null(self$weight)) cb$weight = assert_number(self$weight)
+      cb
+    }
+  ),
+  active = list(
+    #' @field weight (`numeric(1)` or `NULL`)\cr
+    #'   Overwrites the `$weight` of the generated [`CallbackSet`], see its section *Ordering*.
+    weight = function(rhs) {
+      if (!missing(rhs)) private$.weight = assert_number(rhs, null.ok = TRUE)
+      private$.weight
     }
   ),
   private = list(
-    .additional_phash_input = function() NULL
+    .weight = NULL,
+    .additional_phash_input = function() private$.weight
   )
 )
 
@@ -295,6 +315,7 @@ torch_callback = function(
   load_state_dict = NULL,
   # other arguments
   initialize = NULL,
+  weight = NULL,
   public = NULL, private = NULL, active = NULL, parent_env = parent.frame(), inherit = CallbackSet,
   lock_objects = FALSE
   ) {
@@ -318,6 +339,7 @@ torch_callback = function(
     # other arguments
     state_dict = state_dict, load_state_dict = load_state_dict,
     initialize = initialize,
+    weight = weight,
     public = public, private = private, active = active, parent_env = parent_env, inherit = inherit,
     lock_objects = lock_objects
   )

--- a/R/learner_torch_methods.R
+++ b/R/learner_torch_methods.R
@@ -115,7 +115,17 @@ learner_torch_train = function(self, private, super, task, param_vals) {
 
 
 train_loop = function(ctx, cbs) {
-  # callbacks such as CallbackSetCheckpoint need access to the other callbacks to save their states
+  # callbacks are called in the order they were passed, unless they request otherwise via their
+  # weight. CallbackSetCheckpoint has weight Inf so that it saves the network and optimizer as the
+  # other callbacks left them at the end of the stage.
+  # order() breaks ties by the second argument, which keeps the order the callbacks were passed in.
+  weights = map_dbl(seq_along(cbs), function(i) {
+    assert_number(cbs[[i]]$weight, .var.name = sprintf("weight of callback '%s'", names(cbs)[[i]] %??% i))
+  })
+  cbs = cbs[order(weights, seq_along(cbs))]
+
+  # callbacks such as CallbackSetCheckpoint need access to the other callbacks to save their states,
+  # in the order they are called in
   ctx$callbacks = cbs
 
   call = function(step_name) {

--- a/man-roxygen/param_callbacks.R
+++ b/man-roxygen/param_callbacks.R
@@ -1,4 +1,5 @@
 #' @param callbacks (`list()` of [`TorchCallback`]s)\cr
 #'  The callbacks used during training.
 #'  Must have unique ids.
-#'  They are executed in the order in which they are provided
+#'  They are executed in the order in which they are provided, unless a callback requests
+#'  otherwise via its `$weight`, see section *Ordering* of [`CallbackSet`].

--- a/man/TorchCallback.Rd
+++ b/man/TorchCallback.Rd
@@ -85,16 +85,24 @@ Other Torch Descriptor:
 \section{Super class}{
 \code{\link[mlr3torch:TorchDescriptor]{TorchDescriptor}} -> \code{TorchCallback}
 }
+\section{Active bindings}{
+  \if{html}{\out{<div class="r6-active-bindings">}}
+  \describe{
+    \item{\code{weight}}{(\code{numeric(1)} or \code{NULL})\cr
+Overwrites the \verb{$weight} of the generated \code{\link{CallbackSet}}, see its section \emph{Ordering}.}
+  }
+  \if{html}{\out{</div>}}
+}
 \section{Methods}{
 \subsection{Public methods}{
   \itemize{
     \item \href{#method-TorchCallback-initialize}{\code{TorchCallback$new()}}
+    \item \href{#method-TorchCallback-generate}{\code{TorchCallback$generate()}}
     \item \href{#method-TorchCallback-clone}{\code{TorchCallback$clone()}}
   }
 }
 \if{html}{\out{<details open><summary>Inherited methods</summary>
 <ul>
-  <li><span class="pkg-link" data-pkg="mlr3torch" data-topic="TorchDescriptor" data-id="generate"><a href='../../mlr3torch/html/TorchDescriptor.html#method-TorchDescriptor-generate'><code>TorchDescriptor$generate()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="mlr3torch" data-topic="TorchDescriptor" data-id="help"><a href='../../mlr3torch/html/TorchDescriptor.html#method-TorchDescriptor-help'><code>TorchDescriptor$help()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="mlr3torch" data-topic="TorchDescriptor" data-id="print"><a href='../../mlr3torch/html/TorchDescriptor.html#method-TorchDescriptor-print'><code>TorchDescriptor$print()</code></a></span></li>
 </ul>
@@ -113,7 +121,8 @@ Other Torch Descriptor:
   label = NULL,
   packages = NULL,
   man = NULL,
-  additional_args = NULL
+  additional_args = NULL,
+  weight = NULL
 )}
     \if{html}{\out{</div>}}
   }
@@ -135,7 +144,22 @@ String in the format \verb{[pkg]::[topic]} pointing to a manual page for this ob
 The referenced help package can be opened via method \verb{$help()}.}
       \item{\code{additional_args}}{(\code{any})\cr
 Additional arguments if necessary. For learning rate schedulers, this is the torch::LRScheduler.}
+      \item{\code{weight}}{(\code{numeric(1)} or \code{NULL})\cr
+Overwrites the \verb{$weight} of the generated \code{\link{CallbackSet}}, see its section \emph{Ordering}.
+If \code{NULL} (default), the callback's own weight is kept.}
     }
+    \if{html}{\out{</div>}}
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TorchCallback-generate"></a>}}
+\if{latex}{\out{\hypertarget{method-TorchCallback-generate}{}}}
+\subsection{\code{TorchCallback$generate()}}{
+  Generates the \code{\link{CallbackSet}}, applying \verb{$weight} if it is set.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{TorchCallback$generate()}
     \if{html}{\out{</div>}}
   }
 }

--- a/man/callback_set.Rd
+++ b/man/callback_set.Rd
@@ -21,6 +21,7 @@ callback_set(
   state_dict = NULL,
   load_state_dict = NULL,
   initialize = NULL,
+  weight = NULL,
   public = NULL,
   private = NULL,
   active = NULL,
@@ -45,6 +46,10 @@ Function that loads a callback state.}
 
 \item{initialize}{(\verb{function()})\cr
 The initialization method of the callback.}
+
+\item{weight}{(\code{numeric(1)})\cr
+Controls when the callback is called within a stage, see section \emph{Ordering} of \code{\link{CallbackSet}}.
+Defaults to \code{0}.}
 
 \item{public, private, active}{(\code{list()})\cr
 Additional public, private, and active fields to add to the callback.}

--- a/man/mlr_callback_set.Rd
+++ b/man/mlr_callback_set.Rd
@@ -52,6 +52,18 @@ These functions perform checks such as that the stages are not accidentally miss
 }
 }
 
+\section{Ordering}{
+
+Within a stage, callbacks are called in the order in which they were passed to the learner.
+A callback can override this via its \verb{$weight} field: callbacks with a higher weight are called
+after those with a lower one, and callbacks with the same weight keep the order in which they
+were passed.
+The default weight is \code{0}.
+This matters for callbacks that observe what the others did, which is why
+\code{\link{CallbackSetCheckpoint}} has weight \code{Inf}: it always runs last and therefore saves the network
+and optimizer as the other callbacks left them at the end of the stage.
+}
+
 \section{Terminate Training}{
 
 If training is to be stopped, it is possible to set the field \verb{$terminate} of \code{\link{ContextTorch}}.
@@ -81,6 +93,9 @@ Other Callback:
     \item{\code{ctx}}{(\code{\link{ContextTorch}} or \code{NULL})\cr
 The evaluation context for the callback.
 This field should always be \code{NULL} except during the \verb{$train()} call of the torch learner.}
+
+    \item{\code{weight}}{(\code{numeric(1)})\cr
+Controls when this callback is called within a stage, see section \emph{Ordering}.}
   }
   \if{html}{\out{</div>}}
 }

--- a/man/mlr_callback_set.checkpoint.Rd
+++ b/man/mlr_callback_set.checkpoint.Rd
@@ -55,6 +55,15 @@ Other Callback:
 \section{Super class}{
 \code{\link[mlr3torch:CallbackSet]{CallbackSet}} -> \code{CallbackSetCheckpoint}
 }
+\section{Public fields}{
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{weight}}{(\code{numeric(1)})\cr
+\code{Inf}, so that this callback runs after all others and hence saves the network and
+optimizer as they are at the end of the stage, see section \emph{Ordering} of \code{\link{CallbackSet}}.}
+  }
+  \if{html}{\out{</div>}}
+}
 \section{Methods}{
 \subsection{Public methods}{
   \itemize{

--- a/man/mlr_learners_torch.Rd
+++ b/man/mlr_learners_torch.Rd
@@ -451,7 +451,9 @@ To deviate from the defaults, it is necessary to overwrite the private \verb{$.e
 method, see section \emph{Inheriting}.}
       \item{\code{callbacks}}{(\code{list()} of \code{\link{TorchCallback}}s)\cr
 The callbacks to use for training.
-Defaults to an empty\code{ list()}, i.e. no callbacks.}
+Defaults to an empty\code{ list()}, i.e. no callbacks.
+Within a stage they are called in the order in which they are provided, unless a callback
+requests otherwise via its \verb{$weight}, see section \emph{Ordering} of \code{\link{CallbackSet}}.}
       \item{\code{jittable}}{(\code{logical(1)})\cr
 Whether the model can be jit-traced. Default is \code{FALSE}.}
     }

--- a/man/mlr_learners_torch_image.Rd
+++ b/man/mlr_learners_torch_image.Rd
@@ -94,7 +94,8 @@ The loss to use for training.}
       \item{\code{callbacks}}{(\code{list()} of \code{\link{TorchCallback}}s)\cr
 The callbacks used during training.
 Must have unique ids.
-They are executed in the order in which they are provided}
+They are executed in the order in which they are provided, unless a callback requests
+otherwise via its \verb{$weight}, see section \emph{Ordering} of \code{\link{CallbackSet}}.}
       \item{\code{packages}}{(\code{character()})\cr
 The R packages this object depends on.}
       \item{\code{man}}{(\code{character(1)})\cr

--- a/man/mlr_learners_torch_model.Rd
+++ b/man/mlr_learners_torch_model.Rd
@@ -145,7 +145,8 @@ The loss to use for training.}
       \item{\code{callbacks}}{(\code{list()} of \code{\link{TorchCallback}}s)\cr
 The callbacks used during training.
 Must have unique ids.
-They are executed in the order in which they are provided}
+They are executed in the order in which they are provided, unless a callback requests
+otherwise via its \verb{$weight}, see section \emph{Ordering} of \code{\link{CallbackSet}}.}
       \item{\code{packages}}{(\code{character()})\cr
 The R packages this object depends on.}
       \item{\code{feature_types}}{(\code{NULL} or \code{character()})\cr

--- a/man/torch_callback.Rd
+++ b/man/torch_callback.Rd
@@ -119,6 +119,18 @@ then wraps this generator in a \code{\link{TorchCallback}} that can be passed to
 }
 }
 
+\section{Ordering}{
+
+Within a stage, callbacks are called in the order in which they were passed to the learner.
+A callback can override this via its \verb{$weight} field: callbacks with a higher weight are called
+after those with a lower one, and callbacks with the same weight keep the order in which they
+were passed.
+The default weight is \code{0}.
+This matters for callbacks that observe what the others did, which is why
+\code{\link{CallbackSetCheckpoint}} has weight \code{Inf}: it always runs last and therefore saves the network
+and optimizer as the other callbacks left them at the end of the stage.
+}
+
 \examples{
 \dontshow{if (torch::torch_is_installed()) withAutoprint(\{ # examplesIf}
 custom_tcb = torch_callback("custom",

--- a/man/torch_callback.Rd
+++ b/man/torch_callback.Rd
@@ -26,6 +26,7 @@ torch_callback(
   state_dict = NULL,
   load_state_dict = NULL,
   initialize = NULL,
+  weight = NULL,
   public = NULL,
   private = NULL,
   active = NULL,
@@ -67,6 +68,10 @@ Function that loads a callback state.}
 
 \item{initialize}{(\verb{function()})\cr
 The initialization method of the callback.}
+
+\item{weight}{(\code{numeric(1)})\cr
+Controls when the callback is called within a stage, see section \emph{Ordering} of \code{\link{CallbackSet}}.
+Defaults to \code{0}.}
 
 \item{public, private, active}{(\code{list()})\cr
 Additional public, private, and active fields to add to the callback.}

--- a/tests/testthat/test_CallbackSet.R
+++ b/tests/testthat/test_CallbackSet.R
@@ -107,6 +107,23 @@ test_that("weight influences the phash", {
   expect_equal(light$phash, heavy$phash)
 })
 
+test_that("weight reaches the hash of a learner using the callback", {
+  # the order the callbacks run in changes what is trained, so two learners that differ only in it
+  # must not be treated as the same learner by tuning, benchmarking or caching
+  make = function(weight = NULL) {
+    cb = t_clbk("history")
+    cb$weight = weight
+    lrn("classif.mlp", epochs = 1L, batch_size = 50, callbacks = cb)
+  }
+
+  expect_equal(make()$hash, make()$hash)
+  expect_equal(make(1)$hash, make(1)$hash)
+
+  expect_false(make()$hash == make(1)$hash)
+  expect_false(make()$phash == make(1)$phash)
+  expect_false(make(1)$hash == make(2)$hash)
+})
+
 test_that("callbacks are called in the order they were passed", {
   order = new.env()
   spy = function(id, ...) torch_callback(id,

--- a/tests/testthat/test_CallbackSet.R
+++ b/tests/testthat/test_CallbackSet.R
@@ -86,3 +86,61 @@ test_that("phash works", {
   expect_false(t_clbk("history", id = "a")$phash == t_clbk("history", id = "b")$phash)
   expect_false(t_clbk("history", label = "a")$phash == t_clbk("history", label = "b")$phash)
 })
+
+test_that("callbacks are called in the order they were passed", {
+  order = new.env()
+  spy = function(id, ...) torch_callback(id,
+    on_epoch_end = function() order$seen = c(order$seen, class(self)[[1L]]), ...)
+
+  run = function(callbacks) {
+    order$seen = NULL
+    lrn("classif.mlp", epochs = 1L, batch_size = 50, neurons = 10,
+      callbacks = callbacks)$train(tsk("iris"))
+    order$seen
+  }
+
+  expect_equal(run(list(spy("a"), spy("b"))), c("CallbackSetA", "CallbackSetB"))
+  expect_equal(run(list(spy("b"), spy("a"))), c("CallbackSetB", "CallbackSetA"))
+})
+
+test_that("weight overrides the order within a stage", {
+  order = new.env()
+  spy = function(id, weight = NULL) torch_callback(id, weight = weight,
+    on_epoch_end = function() order$seen = c(order$seen, class(self)[[1L]]))
+
+  run = function(callbacks) {
+    order$seen = NULL
+    lrn("classif.mlp", epochs = 1L, batch_size = 50, neurons = 10,
+      callbacks = callbacks)$train(tsk("iris"))
+    order$seen
+  }
+
+  # a higher weight runs later, whatever the order the callbacks were passed in
+  expect_equal(run(list(spy("a", weight = 1), spy("b"))), c("CallbackSetB", "CallbackSetA"))
+  expect_equal(run(list(spy("b"), spy("a", weight = 1))), c("CallbackSetB", "CallbackSetA"))
+  expect_equal(run(list(spy("a", weight = -1), spy("b"))), c("CallbackSetA", "CallbackSetB"))
+
+  # equal weights keep the order they were passed in
+  expect_equal(run(list(spy("a", weight = 2), spy("b", weight = 2))),
+    c("CallbackSetA", "CallbackSetB"))
+})
+
+test_that("the checkpoint callback runs last", {
+  # it has weight Inf, so it saves the network as the other callbacks left it
+  cb = t_clbk("checkpoint", freq = 1, path = tempfile())$generate()
+  expect_equal(cb$weight, Inf)
+  expect_equal(CallbackSet$new()$weight, 0)
+})
+
+test_that("weight is validated", {
+  expect_error(torch_callback("bad", weight = "high", on_begin = function() NULL), "weight")
+  expect_error(torch_callback("bad", weight = NaN, on_begin = function() NULL), "weight")
+
+  # a class that declares a nonsensical weight is caught before training rather than producing an
+  # arbitrary order
+  bad = R6::R6Class("CallbackSetBad", inherit = CallbackSet,
+    public = list(weight = NaN, on_epoch_end = function() NULL))
+  learner = lrn("classif.mlp", epochs = 1L, batch_size = 50, neurons = 10,
+    callbacks = list(TorchCallback$new(bad, param_set = ps(), id = "bad")))
+  expect_error(learner$train(tsk("iris")), "weight")
+})

--- a/tests/testthat/test_CallbackSet.R
+++ b/tests/testthat/test_CallbackSet.R
@@ -87,6 +87,26 @@ test_that("phash works", {
   expect_false(t_clbk("history", label = "a")$phash == t_clbk("history", label = "b")$phash)
 })
 
+test_that("weight influences the phash", {
+  # two callbacks that differ only in when they are called are not interchangeable
+  light = t_clbk("history")
+  heavy = t_clbk("history")
+  expect_equal(light$phash, heavy$phash)
+
+  heavy$weight = 1
+  expect_false(light$phash == heavy$phash)
+
+  # the same weight hashes the same, whether it was set at construction or afterwards
+  at_construction = TorchCallback$new(CallbackSetHistory, id = "history", weight = 1)
+  afterwards = TorchCallback$new(CallbackSetHistory, id = "history")
+  afterwards$weight = 1
+  expect_equal(at_construction$phash, afterwards$phash)
+
+  # and clearing it again is not a one-way trip
+  heavy$weight = NULL
+  expect_equal(light$phash, heavy$phash)
+})
+
 test_that("callbacks are called in the order they were passed", {
   order = new.env()
   spy = function(id, ...) torch_callback(id,

--- a/tests/testthat/test_ContextTorch.R
+++ b/tests/testthat/test_ContextTorch.R
@@ -1,6 +1,8 @@
 test_that("the context exposes the callbacks of the training run", {
   seen = NULL
-  spy = torch_callback("spy", on_begin = function() seen <<- self$ctx$callbacks)
+  spy = torch_callback("spy", on_begin = function() {
+    seen <<- self$ctx$callbacks
+  })
 
   learner = lrn("classif.mlp", epochs = 1L, batch_size = 50, neurons = 10,
     callbacks = list(spy, t_clbk("history")))
@@ -14,7 +16,9 @@ test_that("the context exposes the callbacks of the training run", {
 
 test_that("the epoch is 0 during the 'begin' stage", {
   epoch = NULL
-  spy = torch_callback("spy", on_begin = function() epoch <<- self$ctx$epoch)
+  spy = torch_callback("spy", on_begin = function() {
+    epoch <<- self$ctx$epoch
+  })
 
   learner = lrn("classif.mlp", epochs = 2L, batch_size = 50, neurons = 10, callbacks = spy)
   learner$train(tsk("iris"))

--- a/tests/testthat/test_LearnerTorchTabM.R
+++ b/tests/testthat/test_LearnerTorchTabM.R
@@ -546,8 +546,6 @@ test_that("the activation can be a name, a module generator or a function", {
   expect_equal(activation_class("relu"), "nn_relu")
   expect_equal(activation_class("nn_gelu"), "nn_gelu")
   expect_equal(activation_class("leaky_relu"), "nn_leaky_relu")
-  # the name is matched case-insensitively, so "ReLU" resolves as well
-  expect_equal(activation_class("ReLU"), "nn_relu")
   # the torch.nn class names of upstream are deliberately not resolved
   expect_error(activation_class("LeakyReLU"), "Cannot resolve the activation")
   expect_equal(activation_class(nn_tanh), "nn_tanh")

--- a/vignettes/articles/callbacks.Rmd
+++ b/vignettes/articles/callbacks.Rmd
@@ -45,6 +45,13 @@ Below, we list all stages that are available, but they are also described in the
 mlr_reflections$torch$callback_stages
 ```
 
+When a learner has more than one callback, they are called within a stage in the order in which they
+were passed to it.
+A callback that has to observe what the others did -- like `t_clbk("checkpoint")`, which saves the
+network and the optimizer as the other callbacks left them -- can override this through its
+`$weight`: a higher weight is called later, and callbacks with the same weight keep the order they
+were passed in.
+
 For the history callback, we see that it runs code at the beginning, before validation starts, and at the end of an epoch.
 
 ```{r}


### PR DESCRIPTION
Callbacks are called in the order they were passed to the learner, which is the wrong order for a callback whose job is to observe what the others did. The new `$weight` field of `CallbackSet` overrides it: a higher weight is called later, equal weights keep the order they were passed in. It can be set through the `weight` argument of `callback_set()` / `torch_callback()`, or on an existing `TorchCallback`, where it also enters the phash.

`t_clbk("checkpoint")` declares weight `Inf`. It saves the network and the optimizer, so it has to run after everything that still modifies them at the end of a stage: a learning rate scheduler passed after it used to step only once the optimizer had already been written, so the checkpoint held a learning rate one step behind the epoch it was named after.

Also fixes the two `implicit_assignment` lints in test_ContextTorch.R, which were introduced with the file and are on main.