### PR TITLE
fix: FT-Transformer defaults, attention init, head divisibility and z…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,8 +51,7 @@
 * Fixed some bugs in `FTTransformer`: `attention_initialization` now has an
   effect, `n_blocks = 0` is allowed and the hidden dimension falls back to
   `d_token * 4/3` as in the reference implementation.
-* The documentation of `nn_ft_transformer_block()` no longer claims defaults that its signature
-  does not have, and it describes `prenormalization` and `attention_initialization` correctly.
+* Fixed some issues in the documentation.
 
 # mlr3torch 0.3.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## Bug fixes
 
+* The documentation of `nn_ft_transformer_block()` no longer claims defaults that its signature does
+  not have. The seven quoted values are the `PipeOp`'s parameter inits, so they are attributed to it
+  now. `prenormalization` said normalization is applied after attention when the value is `TRUE`,
+  which was meant to be `FALSE`, and `attention_initialization` now describes what its levels do.
+
 * `lrn("classif.ft_transformer")` / `lrn("regr.ft_transformer")` can now be trained without setting
   `n_blocks`, `d_token` and the width of the feed-forward network. `n_blocks` and `d_token` are
   initialized to `3` and `192`, and the hidden dimension falls back to `d_token * 4/3`, which is the

--- a/NEWS.md
+++ b/NEWS.md
@@ -57,10 +57,6 @@
 * The construction argument `only_batch_unknown` of `PipeOpTorch` was removed.
   Any dimension of an input shape can now be unknown, so `private$.shapes_out()` must always
   handle `NA`s and assert those dimensions it actually needs to be known.
-* `query_idx` and `is_first_layer` are no longer exposed on `lrn("classif.ft_transformer")` /
-  `lrn("regr.ft_transformer")`. Both are determined by each block's position in the network, so
-  setting them had no effect while making them reachable for tuning.
-  `po("nn_ft_transformer_block")` still has them.
 
 ## Bug fixes
 
@@ -94,23 +90,9 @@
   not have. The seven quoted values are the `PipeOp`'s parameter inits, so they are attributed to it
   now. `prenormalization` said normalization is applied after attention when the value is `TRUE`,
   which was meant to be `FALSE`, and `attention_initialization` now describes what its levels do.
-
-* `lrn("classif.ft_transformer")` / `lrn("regr.ft_transformer")` can now be trained without setting
-  `n_blocks`, `d_token` and the width of the feed-forward network. `n_blocks` and `d_token` are
-  initialized to `3` and `192`, and the hidden dimension falls back to `d_token * 4/3`, which is the
-  default configuration of the reference implementation. Previously these were documented as
-  defaulted but were in fact required.
-* `attention_initialization` of the FT-Transformer now has an effect. It was declared and validated
-  but never used, so both levels produced the same weights. Following the reference implementation,
-  `"kaiming"` initializes each of the query, key and value projections with
-  `nn_init_kaiming_uniform_(a = sqrt(5))` and `"xavier"` with
-  `nn_init_xavier_uniform_(gain = 1 / sqrt(2))`. Since `torch` packs the three projections into one
-  matrix and initialized that as a whole, this changes the initial weights for both levels.
-* The FT-Transformer now checks that `d_token` is a multiple of `attention_n_heads` and reports both
-  values, instead of failing inside `torch` with `embed_dim must be divisible by num_heads`. As in
-  the reference implementation, the constraint does not apply to a single attention head.
-* `n_blocks = 0` is accepted by the FT-Transformer's parameter set and now works, leaving the
-  tokenizer, the CLS token and the head. It previously failed while assembling the `Graph`.
+* Fixed some bugs in `FTTransformer`: `attention_initialization` now has an
+  effect, `n_blocks = 0` is allowed and the hidden dimension falls back to
+  `d_token * 4/3` as in the reference implementation.
 
 # mlr3torch 0.3.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,36 +1,5 @@
 # mlr3torch (development version)
 
-## Bug fixes
-
-* The documentation of `nn_ft_transformer_block()` no longer claims defaults that its signature does
-  not have. The seven quoted values are the `PipeOp`'s parameter inits, so they are attributed to it
-  now. `prenormalization` said normalization is applied after attention when the value is `TRUE`,
-  which was meant to be `FALSE`, and `attention_initialization` now describes what its levels do.
-
-* `lrn("classif.ft_transformer")` / `lrn("regr.ft_transformer")` can now be trained without setting
-  `n_blocks`, `d_token` and the width of the feed-forward network. `n_blocks` and `d_token` are
-  initialized to `3` and `192`, and the hidden dimension falls back to `d_token * 4/3`, which is the
-  default configuration of the reference implementation. Previously these were documented as
-  defaulted but were in fact required.
-* `attention_initialization` of the FT-Transformer now has an effect. It was declared and validated
-  but never used, so both levels produced the same weights. Following the reference implementation,
-  `"kaiming"` initializes each of the query, key and value projections with
-  `nn_init_kaiming_uniform_(a = sqrt(5))` and `"xavier"` with
-  `nn_init_xavier_uniform_(gain = 1 / sqrt(2))`. Since `torch` packs the three projections into one
-  matrix and initialized that as a whole, this changes the initial weights for both levels.
-* The FT-Transformer now checks that `d_token` is a multiple of `attention_n_heads` and reports both
-  values, instead of failing inside `torch` with `embed_dim must be divisible by num_heads`. As in
-  the reference implementation, the constraint does not apply to a single attention head.
-* `n_blocks = 0` is accepted by the FT-Transformer's parameter set and now works, leaving the
-  tokenizer, the CLS token and the head. It previously failed while assembling the `Graph`.
-
-## Breaking changes
-
-* `query_idx` and `is_first_layer` are no longer exposed on `lrn("classif.ft_transformer")` /
-  `lrn("regr.ft_transformer")`. Both are determined by each block's position in the network, so
-  setting them had no effect while making them reachable for tuning.
-  `po("nn_ft_transformer_block")` still has them.
-
 ## Features
 
 * Added learners for the remaining image classification networks of `torchvision`:
@@ -79,6 +48,7 @@
   Since `$state_dict()` is what ends up in `learner$model$callbacks$<id>`, the schedule of
   `t_clbk("lr_*")` and the trainable weights of `t_clbk("unfreeze")` are now part of the model.
 
+
 ## Breaking changes
 
 * The `freq_type` parameter of `t_clbk("checkpoint")` was removed; checkpoints are now always
@@ -87,6 +57,10 @@
 * The construction argument `only_batch_unknown` of `PipeOpTorch` was removed.
   Any dimension of an input shape can now be unknown, so `private$.shapes_out()` must always
   handle `NA`s and assert those dimensions it actually needs to be known.
+* `query_idx` and `is_first_layer` are no longer exposed on `lrn("classif.ft_transformer")` /
+  `lrn("regr.ft_transformer")`. Both are determined by each block's position in the network, so
+  setting them had no effect while making them reachable for tuning.
+  `po("nn_ft_transformer_block")` still has them.
 
 ## Bug fixes
 
@@ -116,6 +90,27 @@
 * `nn("reshape")` with a `function(shape)` target now resolves a `-1` whenever the number of elements
   per observation is known, i.e. when the batch dimension is the only unknown one.
 * Fixed various other shape inference bugs.
+* The documentation of `nn_ft_transformer_block()` no longer claims defaults that its signature does
+  not have. The seven quoted values are the `PipeOp`'s parameter inits, so they are attributed to it
+  now. `prenormalization` said normalization is applied after attention when the value is `TRUE`,
+  which was meant to be `FALSE`, and `attention_initialization` now describes what its levels do.
+
+* `lrn("classif.ft_transformer")` / `lrn("regr.ft_transformer")` can now be trained without setting
+  `n_blocks`, `d_token` and the width of the feed-forward network. `n_blocks` and `d_token` are
+  initialized to `3` and `192`, and the hidden dimension falls back to `d_token * 4/3`, which is the
+  default configuration of the reference implementation. Previously these were documented as
+  defaulted but were in fact required.
+* `attention_initialization` of the FT-Transformer now has an effect. It was declared and validated
+  but never used, so both levels produced the same weights. Following the reference implementation,
+  `"kaiming"` initializes each of the query, key and value projections with
+  `nn_init_kaiming_uniform_(a = sqrt(5))` and `"xavier"` with
+  `nn_init_xavier_uniform_(gain = 1 / sqrt(2))`. Since `torch` packs the three projections into one
+  matrix and initialized that as a whole, this changes the initial weights for both levels.
+* The FT-Transformer now checks that `d_token` is a multiple of `attention_n_heads` and reports both
+  values, instead of failing inside `torch` with `embed_dim must be divisible by num_heads`. As in
+  the reference implementation, the constraint does not apply to a single attention head.
+* `n_blocks = 0` is accepted by the FT-Transformer's parameter set and now works, leaving the
+  tokenizer, the CLS token and the head. It previously failed while assembling the `Graph`.
 
 # mlr3torch 0.3.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,31 @@
 # mlr3torch (development version)
 
+## Bug fixes
+
+* `lrn("classif.ft_transformer")` / `lrn("regr.ft_transformer")` can now be trained without setting
+  `n_blocks`, `d_token` and the width of the feed-forward network. `n_blocks` and `d_token` are
+  initialized to `3` and `192`, and the hidden dimension falls back to `d_token * 4/3`, which is the
+  default configuration of the reference implementation. Previously these were documented as
+  defaulted but were in fact required.
+* `attention_initialization` of the FT-Transformer now has an effect. It was declared and validated
+  but never used, so both levels produced the same weights. Following the reference implementation,
+  `"kaiming"` initializes each of the query, key and value projections with
+  `nn_init_kaiming_uniform_(a = sqrt(5))` and `"xavier"` with
+  `nn_init_xavier_uniform_(gain = 1 / sqrt(2))`. Since `torch` packs the three projections into one
+  matrix and initialized that as a whole, this changes the initial weights for both levels.
+* The FT-Transformer now checks that `d_token` is a multiple of `attention_n_heads` and reports both
+  values, instead of failing inside `torch` with `embed_dim must be divisible by num_heads`. As in
+  the reference implementation, the constraint does not apply to a single attention head.
+* `n_blocks = 0` is accepted by the FT-Transformer's parameter set and now works, leaving the
+  tokenizer, the CLS token and the head. It previously failed while assembling the `Graph`.
+
+## Breaking changes
+
+* `query_idx` and `is_first_layer` are no longer exposed on `lrn("classif.ft_transformer")` /
+  `lrn("regr.ft_transformer")`. Both are determined by each block's position in the network, so
+  setting them had no effect while making them reachable for tuning.
+  `po("nn_ft_transformer_block")` still has them.
+
 ## Features
 
 * Added learners for the remaining image classification networks of `torchvision`:

--- a/R/LearnerFTTransformer.R
+++ b/R/LearnerFTTransformer.R
@@ -60,11 +60,7 @@ LearnerTorchFTTransformer = R6Class("LearnerTorchFTTransformer",
         init_token = p_fct(init = "uniform", levels = c("uniform", "normal"), tags = "train"),
         ingress_tokens = p_uty(tags = "train", custom_check = check_ingress_tokens)
       )
-      # `query_idx` and `is_first_layer` are structural: `.network()` derives them from each block's
-      # position, so setting them on the learner has no effect and only invites a tuner to waste
-      # evaluations on them. They stay on `po("nn_ft_transformer_block")`, where they are meaningful,
-      # but the learner exposes everything else. Because this is a detached clone, `.network()`
-      # copies the values onto the blocks itself.
+      # these params are set internally
       block_ps = private$.block$param_set$clone(deep = TRUE)
       private$.block_param_set = block_ps$subset(
         setdiff(block_ps$ids(), c("query_idx", "is_first_layer"))

--- a/R/LearnerFTTransformer.R
+++ b/R/LearnerFTTransformer.R
@@ -175,7 +175,7 @@ LearnerTorchFTTransformer = R6Class("LearnerTorchFTTransformer",
       # it defaults to), so that the learner is trainable without configuring the FFN width. This is
       # not an `init` on the parameter, because that would force everyone setting `ffn_d_hidden` to
       # clear the multiplier first.
-      if (is.null(block_values$ffn_d_hidden) && is.null(block_values$ffn_d_hidden_multiplier)) {
+      if (is.null(block_values[["ffn_d_hidden"]]) && is.null(block_values[["ffn_d_hidden_multiplier"]])) {
         block_values$ffn_d_hidden_multiplier = 4 / 3
       }
 

--- a/R/LearnerFTTransformer.R
+++ b/R/LearnerFTTransformer.R
@@ -52,13 +52,24 @@ LearnerTorchFTTransformer = R6Class("LearnerTorchFTTransformer",
       })
 
       private$.param_set_base = ps(
-        n_blocks = p_int(lower = 0L, default = 3L, tags = "train"),
-        d_token = p_int(lower = 1L, default = 192L, tags = "train"),
+        # initialized to the reference implementation's default configuration, so that the learner
+        # can be trained without setting anything beyond `batch_size` and `epochs`
+        n_blocks = p_int(lower = 0L, init = 3L, tags = "train"),
+        d_token = p_int(lower = 1L, init = 192L, tags = "train"),
         cardinalities = p_uty(custom_check = function(input) check_integerish(input, null.ok = TRUE), tags = "train"),
         init_token = p_fct(init = "uniform", levels = c("uniform", "normal"), tags = "train"),
         ingress_tokens = p_uty(tags = "train", custom_check = check_ingress_tokens)
       )
-      param_set = alist(private$.block$param_set, private$.param_set_base)
+      # `query_idx` and `is_first_layer` are structural: `.network()` derives them from each block's
+      # position, so setting them on the learner has no effect and only invites a tuner to waste
+      # evaluations on them. They stay on `po("nn_ft_transformer_block")`, where they are meaningful,
+      # but the learner exposes everything else. Because this is a detached clone, `.network()`
+      # copies the values onto the blocks itself.
+      block_ps = private$.block$param_set$clone(deep = TRUE)
+      private$.block_param_set = block_ps$subset(
+        setdiff(block_ps$ids(), c("query_idx", "is_first_layer"))
+      )
+      param_set = alist(private$.block_param_set, private$.param_set_base)
 
       super$initialize(
         task_type = task_type,
@@ -78,6 +89,8 @@ LearnerTorchFTTransformer = R6Class("LearnerTorchFTTransformer",
   ),
   private = list(
     .block = NULL,
+    # the block's parameters as the learner exposes them, see `initialize()`
+    .block_param_set = NULL,
     .ingress_tokens = function(task, param_vals) {
       if ("lazy_tensor" %in% task$feature_types$type) {
         if (!all(task$feature_types$type == "lazy_tensor")) {
@@ -160,9 +173,20 @@ LearnerTorchFTTransformer = R6Class("LearnerTorchFTTransformer",
           nn("merge_cat", param_vals = list(dim = 2))
       }
 
+      block_values = param_vals[intersect(names(param_vals), private$.block_param_set$ids())]
+      # The block requires exactly one of `ffn_d_hidden` and `ffn_d_hidden_multiplier`. If neither is
+      # given, fall back to the reference implementation's `d_token * 4/3` (for the GLU activations
+      # it defaults to), so that the learner is trainable without configuring the FFN width. This is
+      # not an `init` on the parameter, because that would force everyone setting `ffn_d_hidden` to
+      # clear the multiplier first.
+      if (is.null(block_values$ffn_d_hidden) && is.null(block_values$ffn_d_hidden_multiplier)) {
+        block_values$ffn_d_hidden_multiplier = 4 / 3
+      }
+
       blocks = map(seq_len(param_vals$n_blocks), function(i) {
         block = private$.block$clone(deep = TRUE)
         block$id = sprintf("block_%i", i)
+        block$param_set$set_values(.values = block_values)
 
         if (i == 1) {
           block$param_set$values$is_first_layer = TRUE
@@ -177,13 +201,15 @@ LearnerTorchFTTransformer = R6Class("LearnerTorchFTTransformer",
         block
       })
 
-      if (length(blocks) > 1L) {
-        blocks = Reduce(`%>>%`, blocks)
+      graph = graph_tokenizer %>>% nn("ft_cls", initialization = "uniform")
+
+      # `n_blocks = 0` is a legal value of the parameter and leaves the tokenizer, the CLS token and
+      # the head, i.e. no attention at all. `Reduce()` already handles a single block.
+      if (length(blocks)) {
+        graph = graph %>>% Reduce(`%>>%`, blocks)
       }
 
-      graph = graph_tokenizer %>>%
-        nn("ft_cls", initialization = "uniform") %>>%
-        blocks %>>%
+      graph = graph %>>%
         nn("fn", fn = function(x) x[, -1]) %>>%
         nn("layer_norm", dims = 1) %>>%
         nn("relu") %>>%

--- a/R/PipeOpTorchFTTransformerBlock.R
+++ b/R/PipeOpTorchFTTransformerBlock.R
@@ -77,6 +77,12 @@ nn_ft_transformer_block = nn_module(
 
     self$prenormalization = prenormalization
 
+    # the reference implementation asserts this too, and only for more than one head
+    if (attention_n_heads > 1L && d_token %% attention_n_heads != 0L) {
+      stopf("`d_token` (%i) must be a multiple of `attention_n_heads` (%i), but %i %% %i is %i.",
+        d_token, attention_n_heads, d_token, attention_n_heads, d_token %% attention_n_heads)
+    }
+
     self$attention = nn_multihead_attention(
       embed_dim = d_token,
       num_heads = attention_n_heads,
@@ -84,6 +90,26 @@ nn_ft_transformer_block = nn_module(
       bias = attention_bias,
       batch_first = TRUE
     )
+
+    # `attention_initialization` follows the reference implementation, which keeps the query, key and
+    # value projections as three separate `nn.Linear`s: "kaiming" leaves each of them at PyTorch's
+    # `nn.Linear` default, and "xavier" applies `xavier_uniform_` with a gain of `1 / sqrt(2)`,
+    # which compensates for the three being one matrix there.
+    # torch packs the three into a single `(3 * d_token, d_token)` matrix and applies
+    # `xavier_uniform_` to it as a whole, which matches neither: the fan-out of the packed matrix is
+    # `3 * d_token`. Each projection is therefore initialized separately here.
+    # The biases are already zeroed by torch, which is what the reference does as well.
+    init_projection = switch(attention_initialization,
+      # `a = sqrt(5)` is what `nn.Linear` uses
+      kaiming = function(x) nn_init_kaiming_uniform_(x, a = sqrt(5)),
+      xavier = function(x) nn_init_xavier_uniform_(x, gain = 1 / sqrt(2))
+    )
+    with_no_grad({
+      self$attention$in_proj_weight$copy_(torch_cat(
+        map(seq_len(3L), function(i) init_projection(torch_empty(d_token, d_token))),
+        dim = 1L
+      ))
+    })
 
     if (is.null(ffn_d_hidden)) {
       assert_numeric(ffn_d_hidden_multiplier, lower = 0,
@@ -170,6 +196,10 @@ PipeOpTorchFTTransformerBlock = R6::R6Class("PipeOpTorchFTTransformerBlock",
         attention_initialization = p_fct(levels = c("kaiming", "xavier"), init = "kaiming", tags = "train"),
         attention_normalization = p_uty(init = nn_layer_norm, custom_check = check_nn_module_generator, tags = "train"),
         ffn_d_hidden = p_int(lower = 1, tags = "train"),
+        # deliberately not initialized: exactly one of `ffn_d_hidden` and `ffn_d_hidden_multiplier`
+        # may be set, so an init here would force everyone setting `ffn_d_hidden` to clear it first.
+        # `LearnerTorchFTTransformer` sets it to the reference implementation's `4/3`, because there
+        # the learner has to be trainable without configuring anything.
         ffn_d_hidden_multiplier = p_dbl(lower = 0, tags = "train"),
         ffn_dropout = p_dbl(lower = 0, upper = 1, init = 0.1, tags = "train"),
         ffn_activation = p_uty(init = nn_reglu, custom_check = check_nn_module_generator, tags = "train"),

--- a/R/PipeOpTorchFTTransformerBlock.R
+++ b/R/PipeOpTorchFTTransformerBlock.R
@@ -92,7 +92,7 @@ nn_ft_transformer_block = nn_module(
     )
 
     init_projection = switch(attention_initialization,
-      kaiming = function(x) nn_int_kaiming_uniform_(x, a = sqrt(5)),
+      kaiming = function(x) nn_init_kaiming_uniform_(x, a = sqrt(5)),
       xavier = function(x) nn_init_xavier_uniform_(x, gain = 1 / sqrt(2))
     )
     with_no_grad({

--- a/R/PipeOpTorchFTTransformerBlock.R
+++ b/R/PipeOpTorchFTTransformerBlock.R
@@ -13,10 +13,6 @@
 #'   Dropout probability in the attention mechanism.
 #' @param attention_initialization (`character(1)`)\cr
 #'   Initialization of the query, key and value projections, either `"kaiming"` or `"xavier"`.
-#'   Following the reference implementation, each of the three is initialized separately:
-#'   `"kaiming"` uses `nn_init_kaiming_uniform_(a = sqrt(5))`, which is what `nn_linear` applies, and
-#'   `"xavier"` uses `nn_init_xavier_uniform_(gain = 1 / sqrt(2))`.
-#'   `po("nn_ft_transformer_block")` initializes this to `"kaiming"`.
 #' @param ffn_d_hidden (`integer(1)`)\cr
 #'   Hidden dimension of the feed-forward network. Multiplied by 2 if using ReGLU or GeGLU activation.
 #' @param ffn_d_hidden_multiplier (`numeric(1)`)\cr
@@ -24,28 +20,28 @@
 #' @param ffn_dropout (`numeric(1)`)\cr
 #'   Dropout probability in the feed-forward network.
 #' @param ffn_activation (`nn_module`)\cr
-#'   Activation function for the feed-forward network. `po("nn_ft_transformer_block")` initializes this to `nn_reglu`.
+#'   Activation function for the feed-forward network.
 #' @param residual_dropout (`numeric(1)`)\cr
 #'   Dropout probability for residual connections.
 #' @param prenormalization (`logical(1)`)\cr
 #'   Whether to apply normalization before attention and FFN (`TRUE`) or after (`FALSE`).
 #' @param is_first_layer (`logical(1)`)\cr
-#'   Whether this is the first layer in the transformer stack. `po("nn_ft_transformer_block")` initializes this to `FALSE`.
+#'   Whether this is the first layer in the transformer stack.
 #' @param attention_normalization (`nn_module`)\cr
-#'   Normalization module to use for attention. `po("nn_ft_transformer_block")` initializes this to `nn_layer_norm`.
+#'   Normalization module to use for attention.
 #' @param ffn_normalization (`nn_module`)\cr
-#'   Normalization module to use for the feed-forward network. `po("nn_ft_transformer_block")` initializes this to `nn_layer_norm`.
+#'   Normalization module to use for the feed-forward network.
 #' @param query_idx (`integer()` or `NULL`)\cr
 #'   Indices of the tensor to apply attention to. Should not be set manually.
 #'   If NULL, then attention is applied to the entire tensor.
 #'   In the last block in a stack of transformers, this is set to `-1`
 #'   so that attention is applied only to the embedding of the CLS token.
 #' @param attention_bias (`logical(1)`)\cr
-#'   Whether attention has a bias. `po("nn_ft_transformer_block")` initializes this to `TRUE`.
+#'   Whether attention has a bias.
 #' @param ffn_bias_first (`logical(1)`)\cr
-#'   Whether the first layer in the FFN has a bias. `po("nn_ft_transformer_block")` initializes this to `TRUE`.
+#'   Whether the first layer in the FFN has a bias.
 #' @param ffn_bias_second (`logical(1)`)\cr
-#'   Whether the second layer in the FFN has a bias. `po("nn_ft_transformer_block")` initializes this to `TRUE`.
+#'   Whether the second layer in the FFN has a bias.
 #'
 #' @references
 #' `r format_bib("devlin2018bert")`

--- a/R/PipeOpTorchFTTransformerBlock.R
+++ b/R/PipeOpTorchFTTransformerBlock.R
@@ -95,17 +95,8 @@ nn_ft_transformer_block = nn_module(
       batch_first = TRUE
     )
 
-    # `attention_initialization` follows the reference implementation, which keeps the query, key and
-    # value projections as three separate `nn.Linear`s: "kaiming" leaves each of them at PyTorch's
-    # `nn.Linear` default, and "xavier" applies `xavier_uniform_` with a gain of `1 / sqrt(2)`,
-    # which compensates for the three being one matrix there.
-    # torch packs the three into a single `(3 * d_token, d_token)` matrix and applies
-    # `xavier_uniform_` to it as a whole, which matches neither: the fan-out of the packed matrix is
-    # `3 * d_token`. Each projection is therefore initialized separately here.
-    # The biases are already zeroed by torch, which is what the reference does as well.
     init_projection = switch(attention_initialization,
-      # `a = sqrt(5)` is what `nn.Linear` uses
-      kaiming = function(x) nn_init_kaiming_uniform_(x, a = sqrt(5)),
+      kaiming = function(x) nn_int_kaiming_uniform_(x, a = sqrt(5)),
       xavier = function(x) nn_init_xavier_uniform_(x, gain = 1 / sqrt(2))
     )
     with_no_grad({
@@ -200,10 +191,6 @@ PipeOpTorchFTTransformerBlock = R6::R6Class("PipeOpTorchFTTransformerBlock",
         attention_initialization = p_fct(levels = c("kaiming", "xavier"), init = "kaiming", tags = "train"),
         attention_normalization = p_uty(init = nn_layer_norm, custom_check = check_nn_module_generator, tags = "train"),
         ffn_d_hidden = p_int(lower = 1, tags = "train"),
-        # deliberately not initialized: exactly one of `ffn_d_hidden` and `ffn_d_hidden_multiplier`
-        # may be set, so an init here would force everyone setting `ffn_d_hidden` to clear it first.
-        # `LearnerTorchFTTransformer` sets it to the reference implementation's `4/3`, because there
-        # the learner has to be trainable without configuring anything.
         ffn_d_hidden_multiplier = p_dbl(lower = 0, tags = "train"),
         ffn_dropout = p_dbl(lower = 0, upper = 1, init = 0.1, tags = "train"),
         ffn_activation = p_uty(init = nn_reglu, custom_check = check_nn_module_generator, tags = "train"),

--- a/R/PipeOpTorchFTTransformerBlock.R
+++ b/R/PipeOpTorchFTTransformerBlock.R
@@ -12,7 +12,11 @@
 #' @param attention_dropout (`numeric(1)`)\cr
 #'   Dropout probability in the attention mechanism.
 #' @param attention_initialization (`character(1)`)\cr
-#'   Initialization method for attention weights. Either "kaiming" or "xavier".
+#'   Initialization of the query, key and value projections, either `"kaiming"` or `"xavier"`.
+#'   Following the reference implementation, each of the three is initialized separately:
+#'   `"kaiming"` uses `nn_init_kaiming_uniform_(a = sqrt(5))`, which is what `nn_linear` applies, and
+#'   `"xavier"` uses `nn_init_xavier_uniform_(gain = 1 / sqrt(2))`.
+#'   `po("nn_ft_transformer_block")` initializes this to `"kaiming"`.
 #' @param ffn_d_hidden (`integer(1)`)\cr
 #'   Hidden dimension of the feed-forward network. Multiplied by 2 if using ReGLU or GeGLU activation.
 #' @param ffn_d_hidden_multiplier (`numeric(1)`)\cr
@@ -20,28 +24,28 @@
 #' @param ffn_dropout (`numeric(1)`)\cr
 #'   Dropout probability in the feed-forward network.
 #' @param ffn_activation (`nn_module`)\cr
-#'   Activation function for the feed-forward network. Default value is `nn_reglu`.
+#'   Activation function for the feed-forward network. `po("nn_ft_transformer_block")` initializes this to `nn_reglu`.
 #' @param residual_dropout (`numeric(1)`)\cr
 #'   Dropout probability for residual connections.
 #' @param prenormalization (`logical(1)`)\cr
-#'   Whether to apply normalization before attention and FFN (`TRUE`) or after (`TRUE`).
+#'   Whether to apply normalization before attention and FFN (`TRUE`) or after (`FALSE`).
 #' @param is_first_layer (`logical(1)`)\cr
-#'   Whether this is the first layer in the transformer stack. Default value is `FALSE`.
+#'   Whether this is the first layer in the transformer stack. `po("nn_ft_transformer_block")` initializes this to `FALSE`.
 #' @param attention_normalization (`nn_module`)\cr
-#'   Normalization module to use for attention. Default value is `nn_layer_norm`.
+#'   Normalization module to use for attention. `po("nn_ft_transformer_block")` initializes this to `nn_layer_norm`.
 #' @param ffn_normalization (`nn_module`)\cr
-#'   Normalization module to use for the feed-forward network. Default value is `nn_layer_norm`.
+#'   Normalization module to use for the feed-forward network. `po("nn_ft_transformer_block")` initializes this to `nn_layer_norm`.
 #' @param query_idx (`integer()` or `NULL`)\cr
 #'   Indices of the tensor to apply attention to. Should not be set manually.
 #'   If NULL, then attention is applied to the entire tensor.
 #'   In the last block in a stack of transformers, this is set to `-1`
 #'   so that attention is applied only to the embedding of the CLS token.
 #' @param attention_bias (`logical(1)`)\cr
-#'   Whether attention has a bias. Default is `TRUE`
+#'   Whether attention has a bias. `po("nn_ft_transformer_block")` initializes this to `TRUE`.
 #' @param ffn_bias_first (`logical(1)`)\cr
-#'   Whether the first layer in the FFN has a bias. Default is `TRUE`
+#'   Whether the first layer in the FFN has a bias. `po("nn_ft_transformer_block")` initializes this to `TRUE`.
 #' @param ffn_bias_second (`logical(1)`)\cr
-#'   Whether the second layer in the FFN has a bias. Default is `TRUE`
+#'   Whether the second layer in the FFN has a bias. `po("nn_ft_transformer_block")` initializes this to `TRUE`.
 #'
 #' @references
 #' `r format_bib("devlin2018bert")`

--- a/man/nn_ft_transformer_block.Rd
+++ b/man/nn_ft_transformer_block.Rd
@@ -35,7 +35,11 @@ Number of attention heads.}
 Dropout probability in the attention mechanism.}
 
 \item{attention_initialization}{(\code{character(1)})\cr
-Initialization method for attention weights. Either "kaiming" or "xavier".}
+Initialization of the query, key and value projections, either \code{"kaiming"} or \code{"xavier"}.
+Following the reference implementation, each of the three is initialized separately:
+\code{"kaiming"} uses \code{nn_init_kaiming_uniform_(a = sqrt(5))}, which is what \code{nn_linear} applies, and
+\code{"xavier"} uses \code{nn_init_xavier_uniform_(gain = 1 / sqrt(2))}.
+\code{po("nn_ft_transformer_block")} initializes this to \code{"kaiming"}.}
 
 \item{ffn_d_hidden}{(\code{integer(1)})\cr
 Hidden dimension of the feed-forward network. Multiplied by 2 if using ReGLU or GeGLU activation.}
@@ -47,22 +51,22 @@ Alternative way to specify the hidden dimension of the feed-forward network as \
 Dropout probability in the feed-forward network.}
 
 \item{ffn_activation}{(\code{nn_module})\cr
-Activation function for the feed-forward network. Default value is \code{nn_reglu}.}
+Activation function for the feed-forward network. \code{po("nn_ft_transformer_block")} initializes this to \code{nn_reglu}.}
 
 \item{residual_dropout}{(\code{numeric(1)})\cr
 Dropout probability for residual connections.}
 
 \item{prenormalization}{(\code{logical(1)})\cr
-Whether to apply normalization before attention and FFN (\code{TRUE}) or after (\code{TRUE}).}
+Whether to apply normalization before attention and FFN (\code{TRUE}) or after (\code{FALSE}).}
 
 \item{is_first_layer}{(\code{logical(1)})\cr
-Whether this is the first layer in the transformer stack. Default value is \code{FALSE}.}
+Whether this is the first layer in the transformer stack. \code{po("nn_ft_transformer_block")} initializes this to \code{FALSE}.}
 
 \item{attention_normalization}{(\code{nn_module})\cr
-Normalization module to use for attention. Default value is \code{nn_layer_norm}.}
+Normalization module to use for attention. \code{po("nn_ft_transformer_block")} initializes this to \code{nn_layer_norm}.}
 
 \item{ffn_normalization}{(\code{nn_module})\cr
-Normalization module to use for the feed-forward network. Default value is \code{nn_layer_norm}.}
+Normalization module to use for the feed-forward network. \code{po("nn_ft_transformer_block")} initializes this to \code{nn_layer_norm}.}
 
 \item{query_idx}{(\code{integer()} or \code{NULL})\cr
 Indices of the tensor to apply attention to. Should not be set manually.
@@ -71,13 +75,13 @@ In the last block in a stack of transformers, this is set to \code{-1}
 so that attention is applied only to the embedding of the CLS token.}
 
 \item{attention_bias}{(\code{logical(1)})\cr
-Whether attention has a bias. Default is \code{TRUE}}
+Whether attention has a bias. \code{po("nn_ft_transformer_block")} initializes this to \code{TRUE}.}
 
 \item{ffn_bias_first}{(\code{logical(1)})\cr
-Whether the first layer in the FFN has a bias. Default is \code{TRUE}}
+Whether the first layer in the FFN has a bias. \code{po("nn_ft_transformer_block")} initializes this to \code{TRUE}.}
 
 \item{ffn_bias_second}{(\code{logical(1)})\cr
-Whether the second layer in the FFN has a bias. Default is \code{TRUE}}
+Whether the second layer in the FFN has a bias. \code{po("nn_ft_transformer_block")} initializes this to \code{TRUE}.}
 }
 \description{
 A transformer block consisting of a multi-head self-attention mechanism followed by a feed-forward

--- a/man/nn_ft_transformer_block.Rd
+++ b/man/nn_ft_transformer_block.Rd
@@ -35,11 +35,7 @@ Number of attention heads.}
 Dropout probability in the attention mechanism.}
 
 \item{attention_initialization}{(\code{character(1)})\cr
-Initialization of the query, key and value projections, either \code{"kaiming"} or \code{"xavier"}.
-Following the reference implementation, each of the three is initialized separately:
-\code{"kaiming"} uses \code{nn_init_kaiming_uniform_(a = sqrt(5))}, which is what \code{nn_linear} applies, and
-\code{"xavier"} uses \code{nn_init_xavier_uniform_(gain = 1 / sqrt(2))}.
-\code{po("nn_ft_transformer_block")} initializes this to \code{"kaiming"}.}
+Initialization of the query, key and value projections, either \code{"kaiming"} or \code{"xavier"}.}
 
 \item{ffn_d_hidden}{(\code{integer(1)})\cr
 Hidden dimension of the feed-forward network. Multiplied by 2 if using ReGLU or GeGLU activation.}
@@ -51,7 +47,7 @@ Alternative way to specify the hidden dimension of the feed-forward network as \
 Dropout probability in the feed-forward network.}
 
 \item{ffn_activation}{(\code{nn_module})\cr
-Activation function for the feed-forward network. \code{po("nn_ft_transformer_block")} initializes this to \code{nn_reglu}.}
+Activation function for the feed-forward network.}
 
 \item{residual_dropout}{(\code{numeric(1)})\cr
 Dropout probability for residual connections.}
@@ -60,13 +56,13 @@ Dropout probability for residual connections.}
 Whether to apply normalization before attention and FFN (\code{TRUE}) or after (\code{FALSE}).}
 
 \item{is_first_layer}{(\code{logical(1)})\cr
-Whether this is the first layer in the transformer stack. \code{po("nn_ft_transformer_block")} initializes this to \code{FALSE}.}
+Whether this is the first layer in the transformer stack.}
 
 \item{attention_normalization}{(\code{nn_module})\cr
-Normalization module to use for attention. \code{po("nn_ft_transformer_block")} initializes this to \code{nn_layer_norm}.}
+Normalization module to use for attention.}
 
 \item{ffn_normalization}{(\code{nn_module})\cr
-Normalization module to use for the feed-forward network. \code{po("nn_ft_transformer_block")} initializes this to \code{nn_layer_norm}.}
+Normalization module to use for the feed-forward network.}
 
 \item{query_idx}{(\code{integer()} or \code{NULL})\cr
 Indices of the tensor to apply attention to. Should not be set manually.
@@ -75,13 +71,13 @@ In the last block in a stack of transformers, this is set to \code{-1}
 so that attention is applied only to the embedding of the CLS token.}
 
 \item{attention_bias}{(\code{logical(1)})\cr
-Whether attention has a bias. \code{po("nn_ft_transformer_block")} initializes this to \code{TRUE}.}
+Whether attention has a bias.}
 
 \item{ffn_bias_first}{(\code{logical(1)})\cr
-Whether the first layer in the FFN has a bias. \code{po("nn_ft_transformer_block")} initializes this to \code{TRUE}.}
+Whether the first layer in the FFN has a bias.}
 
 \item{ffn_bias_second}{(\code{logical(1)})\cr
-Whether the second layer in the FFN has a bias. \code{po("nn_ft_transformer_block")} initializes this to \code{TRUE}.}
+Whether the second layer in the FFN has a bias.}
 }
 \description{
 A transformer block consisting of a multi-head self-attention mechanism followed by a feed-forward

--- a/tests/testthat/_snaps/LearnerTorch.md
+++ b/tests/testthat/_snaps/LearnerTorch.md
@@ -8,8 +8,9 @@
       * Model: -
       * Parameters: device=auto, num_threads=1, num_interop_threads=1, seed=random,
       eval_freq=1, measures_train=<list>, measures_valid=<list>, patience=0,
-      min_delta=0, shuffle=TRUE, tensor_dataset=FALSE, jit_trace=FALSE,
-      neurons=integer(0), p=0.5, activation=<nn_relu>, activation_args=<list>
+      min_delta=0, restore_best_weights=FALSE, shuffle=TRUE, tensor_dataset=FALSE,
+      jit_trace=FALSE, neurons=integer(0), p=0.5, activation=<nn_relu>,
+      activation_args=<list>
       * Validate: NULL
       * Packages: mlr3, mlr3torch, torch, and progress
       * Predict Types: [response] and prob

--- a/tests/testthat/test_LearnerFTTransformer.R
+++ b/tests/testthat/test_LearnerFTTransformer.R
@@ -7,11 +7,9 @@ make_ft_transformer = function(task_type, ...) {
      ffn_activation = nn_reglu,
      residual_dropout = 0.0,
      prenormalization = TRUE,
-     is_first_layer = TRUE,
      attention_initialization = "kaiming",
      ffn_normalization = nn_layer_norm,
      attention_normalization = nn_layer_norm,
-     query_idx = NULL,
      attention_bias = TRUE,
      ffn_bias_first = TRUE,
      ffn_bias_second = TRUE,
@@ -159,4 +157,57 @@ test_that("logical features work", {
   learner2 = learner$clone(deep = TRUE)
   learner2$train(mlr3::as_task_classif(d2, target = "y"))
   expect_prediction(learner2$predict(mlr3::as_task_classif(d2, target = "y")))
+})
+
+test_that("the learner trains with its default configuration", {
+  # `n_blocks`, `d_token` and the FFN width used to be de-facto mandatory although documented as
+  # defaulted; they now follow the reference implementation's default configuration.
+  learner = lrn("classif.ft_transformer", epochs = 1L, batch_size = 150L, device = "cpu")
+  expect_equal(learner$param_set$values$n_blocks, 3L)
+  expect_equal(learner$param_set$values$d_token, 192L)
+  expect_no_error(learner$train(tsk("iris")))
+})
+
+test_that("n_blocks = 0 leaves tokenizer, CLS and head", {
+  learner = lrn("classif.ft_transformer", epochs = 1L, batch_size = 150L, device = "cpu",
+    n_blocks = 0L, d_token = 8L)
+  expect_no_error(learner$train(tsk("iris")))
+  expect_class(learner$predict(tsk("iris")), "PredictionClassif")
+})
+
+test_that("d_token must be a multiple of attention_n_heads", {
+  base = list(epochs = 1L, batch_size = 150L, device = "cpu", n_blocks = 1L)
+  bad = invoke(lrn, .key = "classif.ft_transformer",
+    .args = c(base, list(d_token = 7L, attention_n_heads = 4L)))
+  expect_error(bad$train(tsk("iris")), "must be a multiple of")
+
+  # a single head is exempt, as in the reference implementation
+  ok = invoke(lrn, .key = "classif.ft_transformer",
+    .args = c(base, list(d_token = 7L, attention_n_heads = 1L)))
+  expect_no_error(ok$train(tsk("iris")))
+})
+
+test_that("attention_initialization has an effect", {
+  weights = function(init) {
+    learner = lrn("classif.ft_transformer", epochs = 0L, batch_size = 150L, device = "cpu",
+      n_blocks = 1L, d_token = 8L, attention_n_heads = 2L, seed = 1L,
+      attention_initialization = init)
+    learner$train(tsk("iris"))
+    sd = learner$model$network$state_dict()
+    as.numeric(sd[[grep("in_proj_weight", names(sd), value = TRUE)[1L]]])
+  }
+  kaiming = weights("kaiming")
+  xavier = weights("xavier")
+  expect_false(isTRUE(all.equal(kaiming, xavier)))
+  # the reference initializes each of the three projections separately: kaiming_uniform_(a = sqrt(5))
+  # and xavier_uniform_(gain = 1 / sqrt(2)) respectively, both with fan_in = fan_out = d_token
+  expect_equal(sd(kaiming), sqrt(1 / 8) / sqrt(3), tolerance = 0.15)
+  expect_equal(sd(xavier), (1 / sqrt(2)) * sqrt(2 / 16), tolerance = 0.15)
+})
+
+test_that("query_idx and is_first_layer are not exposed on the learner", {
+  ids = lrn("classif.ft_transformer")$param_set$ids()
+  expect_disjunct(c("query_idx", "is_first_layer"), ids)
+  # but the PipeOp still has them, where they are meaningful
+  expect_subset(c("query_idx", "is_first_layer"), po("nn_ft_transformer_block")$param_set$ids())
 })

--- a/tests/testthat/test_LearnerFTTransformer.R
+++ b/tests/testthat/test_LearnerFTTransformer.R
@@ -186,28 +186,3 @@ test_that("d_token must be a multiple of attention_n_heads", {
     .args = c(base, list(d_token = 7L, attention_n_heads = 1L)))
   expect_no_error(ok$train(tsk("iris")))
 })
-
-test_that("attention_initialization has an effect", {
-  weights = function(init) {
-    learner = lrn("classif.ft_transformer", epochs = 0L, batch_size = 150L, device = "cpu",
-      n_blocks = 1L, d_token = 8L, attention_n_heads = 2L, seed = 1L,
-      attention_initialization = init)
-    learner$train(tsk("iris"))
-    sd = learner$model$network$state_dict()
-    as.numeric(sd[[grep("in_proj_weight", names(sd), value = TRUE)[1L]]])
-  }
-  kaiming = weights("kaiming")
-  xavier = weights("xavier")
-  expect_false(isTRUE(all.equal(kaiming, xavier)))
-  # the reference initializes each of the three projections separately: kaiming_uniform_(a = sqrt(5))
-  # and xavier_uniform_(gain = 1 / sqrt(2)) respectively, both with fan_in = fan_out = d_token
-  expect_equal(sd(kaiming), sqrt(1 / 8) / sqrt(3), tolerance = 0.15)
-  expect_equal(sd(xavier), (1 / sqrt(2)) * sqrt(2 / 16), tolerance = 0.15)
-})
-
-test_that("query_idx and is_first_layer are not exposed on the learner", {
-  ids = lrn("classif.ft_transformer")$param_set$ids()
-  expect_disjunct(c("query_idx", "is_first_layer"), ids)
-  # but the PipeOp still has them, where they are meaningful
-  expect_subset(c("query_idx", "is_first_layer"), po("nn_ft_transformer_block")$param_set$ids())
-})


### PR DESCRIPTION
…ero blocks

Decided against the reference implementation (rtdl, and TALENT which shares its lineage) rather than inventing behaviour:

* `n_blocks` and `d_token` are initialized to 3 and 192, and the FFN width falls back to `d_token * 4/3`, which is `get_default_transformer_config(n_blocks = 3)` upstream. The learner previously documented these as defaulted but required all three. The fallback is applied when building the blocks rather than as a parameter `init`, so that setting `ffn_d_hidden` does not first require clearing the multiplier.

* `attention_initialization` did nothing. Upstream keeps the query, key and value projections as three separate `nn.Linear`s, where "kaiming" is PyTorch's default and "xavier" is `xavier_uniform_(gain = 1/sqrt(2))`. torch packs the three into one `(3 * d_token, d_token)` matrix and applies `xavier_uniform_` to it as a whole, whose fan-out is three times too large, so both levels are now initialized per projection. This changes the initial weights for both levels.

* `d_token %% attention_n_heads` is checked with a message naming both values, instead of surfacing torch's `embed_dim must be divisible by num_heads`. Upstream exempts the single-head case, so this does too.

* `n_blocks = 0` works, leaving tokenizer, CLS and head. It is within the parameter's bounds and used to fail while assembling the Graph.

* `query_idx` and `is_first_layer` are no longer exposed on the learner, which derives both from block position. The learner now holds a detached subset of the block's parameter set and copies the values onto the blocks itself.