### PR TITLE
fix: make graph-built learners reproducible from their seed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # mlr3torch (development version)
 
+## Bug fixes
+
+* Learners built from a `Graph` -- i.e. via `po("torch_model_classif")` / `po("torch_model_regr")` --
+  are now reproducible from their `seed`. The `PipeOpTorch` operators construct their modules while
+  the `Graph` itself trains, which happens before the learner sets the torch seed, so the weight
+  initialization was drawn outside the seeded region and repeated runs of the same learner gave
+  different results. The network is now re-initialized inside that region. A network passed to
+  `LearnerTorchModel` directly is left untouched, since its weights may be the point.
+
 ## Features
 
 * Added learners for the remaining image classification networks of `torchvision`:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,5 @@
 # mlr3torch (development version)
 
-## Bug fixes
-
-* Learners built from a `Graph` -- i.e. via `po("torch_model_classif")` / `po("torch_model_regr")` --
-  are now reproducible from their `seed`. The `PipeOpTorch` operators construct their modules while
-  the `Graph` itself trains, which happens before the learner sets the torch seed, so the weight
-  initialization was drawn outside the seeded region and repeated runs of the same learner gave
-  different results. The network is now re-initialized inside that region. A network passed to
-  `LearnerTorchModel` directly is left untouched, since its weights may be the point.
-
 ## Features
 
 * Added learners for the remaining image classification networks of `torchvision`:
@@ -94,6 +85,10 @@
 * `nn("reshape")` with a `function(shape)` target now resolves a `-1` whenever the number of elements
   per observation is known, i.e. when the batch dimension is the only unknown one.
 * Fixed various other shape inference bugs.
+* `po("torch_model_{regr, classif}")` now resets the parameters of the network
+  at the beginning of `$train()` when the network is built from `PipeOpTorch` objects,
+  which makes the results reproducible for the set `seed` parameter.
+
 
 # mlr3torch 0.3.3
 

--- a/R/LearnerTorchModel.R
+++ b/R/LearnerTorchModel.R
@@ -120,6 +120,15 @@ LearnerTorchModel = R6Class("LearnerTorchModel",
         torch_load(private$.network_stored)
       }
       private$.network_stored = NULL
+      if (isTRUE(private$.reset_parameters_)) {
+        # `PipeOpTorch` operators build their modules while the *Graph* trains, which happens before
+        # `LearnerTorch$.train()` sets the torch seed, so the weights of a graph-built network are
+        # drawn outside the seeded region and such a learner is not reproducible from `seed` alone.
+        # `.network()` runs inside that region, so re-initializing here puts the initialization back
+        # under the seed. Only `PipeOpTorchModel` sets this; a network handed to `LearnerTorchModel`
+        # directly is left alone, as its weights may be the point (e.g. a pretrained model).
+        network$reset_parameters()
+      }
       network
     },
     .dataset = function(task, param_vals) {
@@ -134,6 +143,8 @@ LearnerTorchModel = R6Class("LearnerTorchModel",
       )
     },
     .network_stored = NULL,
+    # set by `PipeOpTorchModel`, see `.network()` above
+    .reset_parameters_ = FALSE,
     .additional_phash_input = function() {
       list(self$properties, self$feature_types, private$.network_stored, self$packages, private$.ingress_tokens_)
      }

--- a/R/PipeOpTorchModel.R
+++ b/R/PipeOpTorchModel.R
@@ -72,6 +72,9 @@ PipeOpTorchModel = R6Class("PipeOpTorchModel",
       # Because we control the creation of the LearnerTorchModel, we know that it's fitted in the same
       # process as the current .train function, hence, we can avoid the serialization round-trip
       get_private(private$.learner, ".network_stored") = network
+      # the modules were constructed above, i.e. outside the learner's seeded region, so the learner
+      # re-initializes them under the seed to make graph-built learners reproducible
+      get_private(private$.learner, ".reset_parameters_") = TRUE
       private$.learner$ingress_tokens = md$ingress
 
       if (is.null(md$loss)) {

--- a/tests/testthat/test_PipeOpTorchModel.R
+++ b/tests/testthat/test_PipeOpTorchModel.R
@@ -156,3 +156,37 @@ test_that("marshaling", {
   pred = glrn$predict(task)
   expect_class(pred, "Prediction")
 })
+
+test_that("graph-built learners are reproducible from the seed", {
+  # `PipeOpTorch` operators build their modules while the Graph trains, i.e. before the learner sets
+  # the torch seed, so the weights used to be drawn outside the seeded region. `PipeOpTorchModel`
+  # now makes the learner re-initialize them under the seed.
+  mk = function(seed) as_learner(
+    po("torch_ingress_num") %>>% po("nn_linear", out_features = 4) %>>% po("nn_head") %>>%
+      po("torch_loss", t_loss("cross_entropy")) %>>% po("torch_optimizer", t_opt("adam")) %>>%
+      po("torch_model_classif", batch_size = 50, epochs = 1, seed = seed, predict_type = "prob"))
+  predict_once = function(seed) {
+    l = mk(seed)
+    l$train(tsk("iris"))
+    l$predict(tsk("iris"))$prob
+  }
+
+  a = predict_once(1L)
+  expect_equal(predict_once(1L), a)
+  expect_false(isTRUE(all.equal(predict_once(2L), a)))
+})
+
+test_that("a network passed to LearnerTorchModel directly is not re-initialized", {
+  # only the pipeop path resets, because a hand-built network's weights may be the point
+  task = tsk("mtcars")
+  network = nn_linear(task$n_features, 1)
+  with_no_grad(network$weight$fill_(0.789))
+
+  learner = LearnerTorchModel$new(network = network, task_type = "regr",
+    ingress_tokens = list(input = ingress_num(shape = c(NA, task$n_features))),
+    optimizer = t_opt("adam", lr = 0), loss = t_loss("mse"))
+  learner$param_set$set_values(batch_size = 32, epochs = 1, seed = 1L)
+  learner$train(task)
+
+  expect_equal(unique(as.numeric(learner$model$network$state_dict()[[1L]])), 0.789, tolerance = 1e-6)
+})


### PR DESCRIPTION
`PipeOpTorch` operators call `.make_module()` while the Graph trains, so the modules of a graph-built network were constructed before `LearnerTorch$.train()` enters its `with_torch_settings(seed = ...)` block. The weight initialization therefore never saw the seed, and two runs of the same learner gave different results, while the equivalent predefined learner was reproducible.

`LearnerTorchModel$.network()` runs inside that block, so `PipeOpTorchModel` now asks it to call `network$reset_parameters()` there. Only that path resets; a network handed to `LearnerTorchModel` directly keeps its weights, which may be the point.

This is safe for the graph path because no pipeop accepts a prebuilt module -- every `nn_*` operator constructs its module from hyperparameters -- so re-initializing only changes which random draw the weights get, which is the intent.