### PR TITLE
fix: the history callback errors when no measures are configured

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # mlr3torch (development version)
 
+## Breaking changes
+
+* The `history` callback now errors when neither `measures_train` nor `measures_valid` is set,
+  instead of silently producing an empty table. It only ever records those two measures -- in
+  particular it never recorded the training loss -- so without them there was nothing to save, which
+  read like training itself had gone wrong. The condition is an `Mlr3ErrorConfig`, so it does not
+  trigger the fallback learner.
+
 ## Features
 
 * Added learners for the remaining image classification networks of `torchvision`:

--- a/R/CallbackSetHistory.R
+++ b/R/CallbackSetHistory.R
@@ -7,6 +7,10 @@
 #' The history is saved as a data.table where the validation measures are prefixed with `"valid."`
 #' and the training measures are prefixed with `"train."`.
 #'
+#' This callback records the `measures_train` and `measures_valid` of the learner and nothing else,
+#' so at least one of them has to be set -- it errors otherwise. In particular the training loss is
+#' not recorded.
+#'
 #' @export
 #' @include CallbackSet.R
 #' @examplesIf torch::torch_is_installed()
@@ -29,7 +33,14 @@ CallbackSetHistory = R6Class("CallbackSetHistory",
   public = list(
     #' @description
     #' Initializes lists where the train and validation metrics are stored.
+    #' Errors if neither `measures_train` nor `measures_valid` is set, as there would be nothing
+    #' to record.
     on_begin = function() {
+      if (!length(self$ctx$measures_train) && !length(self$ctx$measures_valid)) {
+        # the callback only ever records these two, so without them it silently produced an empty
+        # table, which reads like the training itself went wrong
+        error_config("The 'history' callback requires 'measures_train' or 'measures_valid' to be set, as it only records those. Set at least one of them, or remove the callback.") # nolint
+      }
       self$train = list(list(epoch = numeric(0)))
       self$valid = list(list(epoch = numeric(0)))
     },

--- a/man/mlr_callback_set.history.Rd
+++ b/man/mlr_callback_set.history.Rd
@@ -8,6 +8,10 @@
 Saves the training and validation history during training.
 The history is saved as a data.table where the validation measures are prefixed with \code{"valid."}
 and the training measures are prefixed with \code{"train."}.
+
+This callback records the \code{measures_train} and \code{measures_valid} of the learner and nothing else,
+so at least one of them has to be set -- it errors otherwise. In particular the training loss is
+not recorded.
 }
 \examples{
 \dontshow{if (torch::torch_is_installed()) withAutoprint(\{ # examplesIf}
@@ -50,6 +54,8 @@ print(learner$model$callbacks$history)
 \if{latex}{\out{\hypertarget{method-CallbackSetHistory-on_begin}{}}}
 \subsection{\code{CallbackSetHistory$on_begin()}}{
   Initializes lists where the train and validation metrics are stored.
+Errors if neither \code{measures_train} nor \code{measures_valid} is set, as there would be nothing
+to record.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{CallbackSetHistory$on_begin()}

--- a/tests/testthat/test_CallbackSetHistory.R
+++ b/tests/testthat/test_CallbackSetHistory.R
@@ -11,9 +11,9 @@ test_that("CallbackSetHistory works", {
 
   learner = lrn("classif.mlp", epochs = 3, batch_size = 1, callbacks = t_clbk("history"), validate = "predefined")
 
-  learner$train(task)
-
-  expect_data_table(learner$model$callbacks$history, nrows = 0)
+  # without any measures there is nothing for the callback to record, which is an error now rather
+  # than an empty table
+  expect_error(learner$train(task), "measures_train")
 
   learner$param_set$set_values(
     measures_train = msrs(c("classif.acc", "classif.ce")),
@@ -34,4 +34,27 @@ test_that("history works with eval_freq", {
   learner$param_set$set_values(eval_freq = 5)
   learner$train(task)
   expect_equal(learner$model$callbacks$history$epoch, c(5, 10))
+})
+
+test_that("history errors when no measures are configured", {
+  # it only records `measures_train` / `measures_valid`, so without them it used to produce an empty
+  # table, which reads like training itself failed
+  learner = lrn("classif.mlp", epochs = 2, batch_size = 50, neurons = 5,
+    callbacks = t_clbk("history"))
+  expect_error(learner$train(tsk("iris")), "measures_train")
+
+  # a configuration error, so it does not trigger the fallback learner
+  err = tryCatch(learner$train(tsk("iris")), error = function(e) e)
+  expect_class(err, "Mlr3ErrorConfig")
+
+  # either one on its own is enough
+  train_only = lrn("classif.mlp", epochs = 2, batch_size = 50, neurons = 5,
+    callbacks = t_clbk("history"), measures_train = msr("classif.ce"))
+  expect_no_error(train_only$train(tsk("iris")))
+  expect_equal(nrow(train_only$model$callbacks$history), 2L)
+
+  valid_only = lrn("classif.mlp", epochs = 2, batch_size = 50, neurons = 5,
+    callbacks = t_clbk("history"), validate = 0.3, measures_valid = msr("classif.ce"))
+  expect_no_error(valid_only$train(tsk("iris")))
+  expect_equal(nrow(valid_only$model$callbacks$history), 2L)
 })

--- a/tests/testthat/test_LearnerTorch.R
+++ b/tests/testthat/test_LearnerTorch.R
@@ -5,7 +5,7 @@ test_that("Basic checks", {
 
 test_that("deep cloning", {
   learner = lrn("classif.torch_featureless", callbacks = "history")
-  learner$param_set$set_values(epochs = 1, batch_size = 1)
+  learner$param_set$set_values(epochs = 1, batch_size = 1, measures_train = msr("classif.ce"))
   task = tsk("iris")
   learner$train(task)
   learner$state$train_task = NULL
@@ -190,7 +190,7 @@ test_that("the state of a trained network contains what it should", {
   task = tsk("mtcars")$select("am")
 
   learner = lrn("regr.torch_featureless", epochs = 0, batch_size = 10,
-    callbacks = t_clbk("history", id = "history1"),
+    callbacks = t_clbk("history", id = "history1"), measures_train = msr("regr.mse"),
     optimizer = t_opt("sgd", lr = 1),
     loss = t_loss("l1")
   )
@@ -391,7 +391,7 @@ test_that("predict parameters do what they should: classification and regression
 
 test_that("quick accessors work", {
   task = tsk("mtcars")
-  learner = lrn("regr.torch_featureless", epochs = 1, batch_size = 1, callbacks = "history")
+  learner = lrn("regr.torch_featureless", epochs = 1, batch_size = 1, callbacks = "history", measures_train = msr("regr.mse"))
   expect_true(is.null(learner$network))
   learner$train(task)
   expect_class(learner$network, "nn_module")


### PR DESCRIPTION
`t_clbk("history")` records `measures_train` and `measures_valid` and nothing else -- not even the training loss -- so with neither set it produced an empty data.table, which reads like training itself failed rather than like a misconfiguration.

It now signals an `Mlr3ErrorConfig`, matching how the dataloader parameters are validated, so it does not trigger the fallback learner. The description says what the callback records and that it needs at least one of the two.

Three tests in test_LearnerTorch.R attached the callback incidentally, to have some callback present while checking cloning, state and accessors; they now set a measure.